### PR TITLE
Add method for LinearAlgebra.norm

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -515,3 +515,15 @@ function Base.transpose(m::GiacMatrix)::GiacMatrix
         return GiacMatrix(ptr, m.cols, m.rows)
     end
 end
+
+"""
+    norm(m::Union{GiacExpr, Vector{GiacExpr}, p=2)::GiacExpr
+
+"""
+function LinearAlgebra.norm(m::Union{T, Vector{T}}, p::Real=2) where {T <: GiacExpr}
+    p == 1   && return invoke_cmd(:l1norm, m)
+    p == 2   && return invoke_cmd(:l2norm, m)
+    p == Inf && return invoke_cmd(:maxnorm, m)
+    p > 0 || throw(ArgumentError("p not positive"))
+    return sum(xᵢ^p for xᵢ ∈ m)^(1/p)
+end

--- a/src/api.jl
+++ b/src/api.jl
@@ -519,11 +519,28 @@ end
 """
     norm(m::Union{GiacExpr, Vector{GiacExpr}, p=2)::GiacExpr
 
+Find the `p`-norm of a `GiacExpr` or an  `AbstractVector` of `GiacExpr`
+elements.
 """
-function LinearAlgebra.norm(m::Union{T, Vector{T}}, p::Real=2) where {T <: GiacExpr}
-    p == 1   && return invoke_cmd(:l1norm, m)
-    p == 2   && return invoke_cmd(:l2norm, m)
-    p == Inf && return invoke_cmd(:maxnorm, m)
+function LinearAlgebra.norm(ex::GiacExpr, p::Real=2)::GiacExpr
+    p == 1   && return invoke_cmd(:l1norm, ex)
+    p == 2   && return invoke_cmd(:l2norm, ex)
+    p == Inf && return invoke_cmd(:maxnorm, ex)
     p > 0 || throw(ArgumentError("p not positive"))
-    return sum(xᵢ^p for xᵢ ∈ m)^(1/p)
+    𝑝 = convert(GiacExpr, p)
+    return sum(xᵢ^𝑝 for xᵢ ∈ ex)^(1/𝑝)
+end
+
+
+"""
+    norm(A::AbstractArray{GiacExpr})::GiacExpr
+
+Compute the `p`-norm (defaulting to `p=2`) as if `A` were a vector of the corresponding length.
+"""
+function LinearAlgebra.norm(A::AbstractArray{GiacExpr}, p::Real=2)::GiacExpr
+    norm(vec(A), p)
+end
+
+function LinearAlgebra.norm(V::AbstractVector{GiacExpr}, p::Real=2)::GiacExpr
+    norm(Commands.list(V), p)
 end

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -126,6 +126,11 @@ function unwrap_const(ex::GiacExpr)
     return ex
 end
 
+function Base.AbstractFloat(x::GiacExpr)
+    is_vector(x) && return [float(xᵢ) for xᵢ ∈ x]
+    float(to_julia(x))
+end
+
 # ============================================================================
 # Scalar Conversion Helpers
 # ============================================================================

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -128,7 +128,9 @@ end
 
 function Base.AbstractFloat(x::GiacExpr)
     is_vector(x) && return [float(xᵢ) for xᵢ ∈ x]
-    float(to_julia(x))
+    is_constant(x) && return float(to_julia(x))
+
+    throw(ArgumentError("Can convert $x to a floating point value"))
 end
 
 # ============================================================================

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -371,7 +371,7 @@ function Base.convert(::Type{Float64}, g::GiacExpr)::Float64
         r = _convert_to_rational(g)
         return Float64(r)
     elseif is_constant(g)
-        float(to_julia(g))
+        Float64(to_julia(g))
     else
         throw(MethodError(convert, (Float64, g)))
     end

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -370,6 +370,8 @@ function Base.convert(::Type{Float64}, g::GiacExpr)::Float64
     elseif t == FRAC
         r = _convert_to_rational(g)
         return Float64(r)
+    elseif is_constant(g)
+        float(to_julia(g))
     else
         throw(MethodError(convert, (Float64, g)))
     end

--- a/test/test_api.jl
+++ b/test/test_api.jl
@@ -88,16 +88,16 @@
             @testset "norm of matrix" begin
                 M = [1 2; 3 4]
                 A = GiacMatrix(M)
-                for p ∈ (1,2,3Inf)
-                    @test norm(M,p) == norm(A,p)
+                for p ∈ (1,2,3, Inf)
+                    @test norm(M,p) ≈ float(norm(A,p))
                 end
             end
 
             @testset "norm of GiacExpr" begin
-                m = [1 2 3]
+                m = [1, 2, 3]
                 a = Giac.Commands.list(m)
-                for p ∈ (1,2,3Inf)
-                    @test norm(m,p) == norm(a,p)
+                for p ∈ (1,2,3, Inf)
+                    @test norm(m,p) ≈ float(norm(a,p))
                 end
 
                 @giac_var x

--- a/test/test_api.jl
+++ b/test/test_api.jl
@@ -84,6 +84,26 @@
                 d = det(A)
                 @test d isa GiacExpr
             end
+
+            @testset "norm of matrix" begin
+                M = [1 2; 3 4]
+                A = GiacMatrix(M)
+                for p ∈ (1,2,3Inf)
+                    @test norm(M,p) == norm(A,p)
+                end
+            end
+
+            @testset "norm of GiacExpr" begin
+                m = [1 2 3]
+                a = Giac.Commands.list(m)
+                for p ∈ (1,2,3Inf)
+                    @test norm(m,p) == norm(a,p)
+                end
+
+                @giac_var x
+                @test norm(x) == abs(x)
+                @test norm([1,x]) == sqrt(1 + x^2)
+            end
         end
 
         # =====================================================================

--- a/test/test_api.jl
+++ b/test/test_api.jl
@@ -88,16 +88,18 @@
             @testset "norm of matrix" begin
                 M = [1 2; 3 4]
                 A = GiacMatrix(M)
+                B = GiacExpr[mi for mi in M]
                 for p ∈ (1,2,3, Inf)
-                    @test norm(M,p) ≈ float(norm(A,p))
+                    @test norm(M,p) ≈ float(norm(A,p)) ≈ float(norm(B,p))
                 end
             end
 
             @testset "norm of GiacExpr" begin
                 m = [1, 2, 3]
                 a = Giac.Commands.list(m)
+                b = GiacExpr[mi for mi in m]
                 for p ∈ (1,2,3, Inf)
-                    @test norm(m,p) ≈ float(norm(a,p))
+                    @test norm(m,p) ≈ float(norm(a,p)) ≈ float(norm(b,p))
                 end
 
                 @giac_var x

--- a/test/test_introspection.jl
+++ b/test/test_introspection.jl
@@ -411,6 +411,7 @@
         @test Giac.unwrap_const(giac_eval("sin(pi/2)")) ≈ 1
         @test Giac.unwrap_const(giac_eval("sin(x)")) == giac_eval("sin(x)")
 
+
         # Issue #19: `infinity` and `undef` are GIAC atoms with no free
         # symbols, so is_constant must report them as constants. The
         # compound infinity forms (`+infinity`, `-infinity`, `inf`,
@@ -442,6 +443,17 @@
         @test !Giac.is_constant(giac_eval("NaN"))
         @test !Giac.is_constant(giac_eval("undefined"))
         @test !Giac.is_constant(giac_eval("unsigned_infinity"))
+    end
+
+    # ========================================================================
+    # float conversion
+    # ========================================================================
+    @testset "float conversion" begin
+        @test float(giac_eval("1")) == 1.0
+        @test float(giac_eval("1.2")) == 1.2
+        @test float(giac_eval("1 + i")) == 1.0 + 1.0*im
+        @test float(giac_eval("1/2")) == 0.5
+        @test float(giac_eval("[1,2,3]")) == [1.0, 2.0, 3.0]
     end
 
     # ========================================================================


### PR DESCRIPTION
The generic use of `LinearAlgebra.norm` causes a recursive error. This PR creates a `norm` method for either `GiacExpr` or `Vector{GiacExpr}`. As well, (like #22 which should be closed in favor of this) by adding a `float` method for `GiacExpr` the generic norm call for `GiacMatrix` will work.

I think I put these two in the appropriate files.