### PR TITLE
fix: latex and mathml no longer re-evaluate their argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`latex` and `mathml` no longer re-evaluate their argument**:
+  `latex(ifactor(360))` returned `"360"` instead of the factorization, and
+  the same expression rendered as `360` in any notebook that consumes the
+  `text/latex` MIME type (Pluto, Jupyter, KaimonSlate).
+  GIAC evaluates command arguments, and `ifactor(360)` is the product
+  `2^3*3^2*5`, which evaluates straight back to `360` — so the form was
+  lost before it could be typeset. `invoke_cmd` now quotes the `GiacExpr`
+  arguments of the rendering commands listed in `Giac.RENDER_COMMANDS`
+  (`:latex`, `:mathml`), on both the direct-`Gen` fast path and the string
+  path, so they typeset the expression as given:
+  `latex(ifactor(360))` → `"5\cdot 2^{3}\cdot 3^{2}"`. Every other command
+  keeps GIAC's normal evaluation semantics. Reported by
+  [@kahliburke](https://github.com/kahliburke).
+
 ## [0.14.1] - 2026-05-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2] - 2026-07-24
+
 ### Fixed
 
 - **`latex` and `mathml` no longer re-evaluate their argument**:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Giac"
 uuid = "e4421f97-9838-4fd0-9fa5-94f11373bf78"
-version = "0.14.1"
+version = "0.14.2"
 authors = ["Sébastien Celles <s.celles@gmail.com>"]
 
 [deps]

--- a/docs/src/api/commands_submodule.md
+++ b/docs/src/api/commands_submodule.md
@@ -43,6 +43,12 @@ Giac.Commands.factor(giac_eval("x^2-1"))
 Giac.Commands.invoke_cmd
 ```
 
+## Rendering Commands
+
+```@docs
+Giac.RENDER_COMMANDS
+```
+
 ## Conflicting Commands
 
 Commands that conflict with Julia keywords, builtins, or standard library functions

--- a/docs/src/pluto.md
+++ b/docs/src/pluto.md
@@ -15,6 +15,34 @@ M = GiacMatrix([1 2; 3 4])  # Matrices render as LaTeX too
 
 This works because Giac.jl implements `Base.show(io, ::MIME"text/latex", expr)` which calls Giac's native `latex` command.
 
+## Rendering preserves the expression you computed
+
+GIAC evaluates the arguments of every command, and not every result is a fixed
+point of evaluation. The integer factorization `ifactor(360)` is the product
+`2^3*3^2*5`, which evaluates straight back to `360`. Giac.jl therefore quotes
+`GiacExpr` arguments passed to the rendering commands (`latex` and `mathml`),
+so they typeset the expression as it stands instead of a re-evaluated copy:
+
+```julia
+using Giac
+using Giac.Commands: ifactor, latex
+
+f = ifactor(360)   # 2^3*3^2*5
+latex(f)           # "5\cdot 2^{3}\cdot 3^{2}"  (not "360")
+```
+
+The same holds for notebook display, so an `ifactor` result shows the
+factorization rather than the original number in any frontend that consumes
+the `text/latex` MIME type — Pluto, Jupyter, or KaimonSlate:
+
+```julia
+ifactor(360)       # renders as 5·2³·3²
+```
+
+Every other command keeps GIAC's normal evaluation semantics — only `latex`
+and `mathml` hold their argument, because they are the ones whose job is to
+show an expression rather than compute with it.
+
 A demo notebook is available at `examples/02_latex.jl`:
 
 ```julia

--- a/src/Commands.jl
+++ b/src/Commands.jl
@@ -60,7 +60,8 @@ using ..Giac: GiacExpr, GiacMatrix, GiacInput, GiacError, giac_eval, with_giac_l
               suggest_commands, _format_suggestions, _warn_conflict,
               _arg_to_giac_string, _build_command_string, help, HelpResult,
               HeldCmd,
-              _fastpath_disabled, _has_direct_gen, _invoke_cmd_direct
+              _fastpath_disabled, _has_direct_gen, _invoke_cmd_direct,
+              RENDER_COMMANDS, _hold_render_arg
 import LinearAlgebra
 
 import CommonSolve: solve
@@ -108,6 +109,20 @@ result = invoke_cmd(:sin, giac_eval("pi/6"))  # Returns 1/2
 result = invoke_cmd(:eval, giac_eval("2+3"))  # Returns 5
 ```
 
+# Rendering commands
+
+The commands listed in [`Giac.RENDER_COMMANDS`](@ref) (`:latex`, `:mathml`)
+typeset their argument rather than compute with it, so their `GiacExpr`
+arguments are quoted before dispatch. Without that, GIAC would re-evaluate the
+argument first and results that are not fixed points of evaluation would lose
+their form — `ifactor(360)` is the product `2^3*3^2*5`, which evaluates back
+to `360`:
+
+```julia
+f = invoke_cmd(:ifactor, 360)   # 2^3*3^2*5
+invoke_cmd(:latex, f)           # "5\\cdot 2^{3}\\cdot 3^{2}", not "360"
+```
+
 # Performance
 
 Since v0.14.2, `invoke_cmd` takes a direct-`Gen` fast path that bypasses the
@@ -136,6 +151,13 @@ function invoke_cmd(cmd::Symbol, args...)::GiacExpr
     # Warn about Julia conflicts (008-all-giac-commands, FR-010)
     # This helps users understand why certain commands can't be exported directly
     _warn_conflict(cmd)
+
+    # Rendering commands (071-latex-render-form): GIAC re-evaluates command
+    # arguments, which collapses results like ifactor(360) == 2^3*3^2*5 back to
+    # 360. Quoting each GiacExpr argument keeps the expression as given.
+    if cmd in RENDER_COMMANDS
+        args = map(_hold_render_arg, args)
+    end
 
     # Fast path (069-invoke-cmd-fastpath): bypass _arg_to_giac_string + giac_eval
     # when every argument has a direct Gen representation. Set

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -827,3 +827,39 @@ function _invoke_cmd_direct(cmd::Symbol, args::Tuple)::GiacExpr
     end
     return GiacExpr(_make_gen_ptr(result_gen))
 end
+
+# ============================================================================
+# Rendering commands: argument holding (071-latex-render-form)
+#
+# GIAC evaluates command arguments, and some results are not fixed points of
+# evaluation: `ifactor(360)` is the product `2^3*3^2*5`, which evaluates back
+# to `360`. Rendering commands must typeset the expression they are handed, so
+# each GiacExpr argument is wrapped in GIAC's `quote(...)` before dispatch.
+# This works on both invoke_cmd paths: the fast path passes the quoted Gen
+# straight to apply_func1, and the string path prints it as `'2^3*3^2*5'`,
+# which the GIAC parser reads back as a quoted expression.
+# ============================================================================
+
+"""
+    RENDER_COMMANDS
+
+GIAC commands that typeset their argument instead of computing with it. Their
+`GiacExpr` arguments are quoted by [`invoke_cmd`](@ref) so that GIAC renders
+the expression as given rather than a re-evaluated copy of it.
+"""
+const RENDER_COMMANDS = (:latex, :mathml)
+
+# Wrap a GiacExpr in GIAC's quote(...) without evaluating it.
+function _quote_gen(expr::GiacExpr)::GiacExpr
+    quoted_gen = with_giac_lock() do
+        args = StdVector{GiacCxxBindings.Gen}()
+        push!(args, _get_gen_or_eval(expr))
+        GiacCxxBindings.make_symbolic_unevaluated("quote", args)
+    end
+    return GiacExpr(_make_gen_ptr(quoted_gen))
+end
+
+# Hold a single rendering-command argument. Only GiacExpr can carry an
+# unevaluated GIAC tree; every other argument type is already a literal.
+_hold_render_arg(x::GiacExpr) = _quote_gen(x)
+_hold_render_arg(@nospecialize(x)) = x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -76,6 +76,9 @@ using LinearAlgebra
     # invoke_cmd fast path tests (069-invoke-cmd-fastpath)
     include("test_invoke_cmd_fastpath.jl")
 
+    # LaTeX/MathML rendering form-preservation tests (071-latex-render-form)
+    include("test_latex_render.jl")
+
     # Output handling tests (029-output-handling)
     include("test_output_handling.jl")
 

--- a/test/test_latex_render.jl
+++ b/test/test_latex_render.jl
@@ -1,0 +1,152 @@
+# Tests for LaTeX/MathML rendering of unevaluated GIAC results
+# (071-latex-render-form).
+#
+# GIAC evaluates command arguments, so handing a result such as
+# `ifactor(360)` (the product 2^3*3^2*5) to `latex` used to collapse it back
+# to 360 before rendering. Rendering commands must print the expression they
+# are given, not a re-evaluated copy of it.
+#
+# Reported by @kahliburke.
+
+using Test
+using Giac
+using Giac: GiacExpr, GiacMatrix, giac_eval, invoke_cmd
+using Giac.Commands: ifactor
+
+# Force the string path for a single block of code (mirrors the helper in
+# test_invoke_cmd_fastpath.jl) so both invoke_cmd paths are covered.
+function _latex_with_string_path(f::Function)
+    prev = get(ENV, "GIAC_INVOKE_CMD_STRING_PATH", nothing)
+    ENV["GIAC_INVOKE_CMD_STRING_PATH"] = "1"
+    Giac._refresh_fastpath_flag!()
+    try
+        return f()
+    finally
+        if prev === nothing
+            delete!(ENV, "GIAC_INVOKE_CMD_STRING_PATH")
+        else
+            ENV["GIAC_INVOKE_CMD_STRING_PATH"] = prev
+        end
+        Giac._refresh_fastpath_flag!()
+    end
+end
+
+@testset "LaTeX rendering preserves expression form (071-latex-render-form)" begin
+
+    # ------------------------------------------------------------------
+    # Foundational: _quote_gen / _hold_render_arg helpers
+    # ------------------------------------------------------------------
+    @testset "Foundational: _quote_gen" begin
+        f = ifactor(360)
+        q = Giac._quote_gen(f)
+        @test q isa GiacExpr
+        # GIAC prints a quoted expression with surrounding single quotes
+        @test string(q) == "'2^3*3^2*5'"
+        # The original expression is untouched
+        @test string(f) == "2^3*3^2*5"
+    end
+
+    @testset "Foundational: _hold_render_arg" begin
+        f = ifactor(360)
+        @test string(Giac._hold_render_arg(f)) == "'2^3*3^2*5'"
+        # Non-GiacExpr arguments pass through unchanged (identity)
+        @test Giac._hold_render_arg(360) === 360
+        @test Giac._hold_render_arg("x^2") === "x^2"
+        @test :latex in Giac.RENDER_COMMANDS
+        @test :mathml in Giac.RENDER_COMMANDS
+    end
+
+    # ------------------------------------------------------------------
+    # US1: latex(ifactor(n)) keeps the factorisation
+    # ------------------------------------------------------------------
+    @testset "US1: invoke_cmd(:latex, ifactor(360))" begin
+        f = ifactor(360)
+        @test string(f) == "2^3*3^2*5"
+
+        tex = string(invoke_cmd(:latex, f))
+        @test occursin("2^{3}", tex)
+        @test occursin("3^{2}", tex)
+        @test !occursin("360", tex)
+    end
+
+    @testset "US1: Commands.latex(ifactor(360))" begin
+        tex = string(Giac.Commands.latex(ifactor(360)))
+        @test occursin("2^{3}", tex)
+        @test occursin("3^{2}", tex)
+        @test !occursin("360", tex)
+    end
+
+    @testset "US1: other ifactor values" begin
+        tex = string(invoke_cmd(:latex, ifactor(1000)))
+        @test occursin("2^{3}", tex)
+        @test occursin("5^{3}", tex)
+        @test !occursin("1000", tex)
+    end
+
+    @testset "US1: string path parity" begin
+        f = ifactor(360)
+        fast = string(invoke_cmd(:latex, f))
+        slow = _latex_with_string_path() do
+            string(invoke_cmd(:latex, f))
+        end
+        @test slow == fast
+        @test occursin("2^{3}", slow)
+        @test !occursin("360", slow)
+    end
+
+    # ------------------------------------------------------------------
+    # US2: notebook display (MIME"text/latex") keeps the factorisation
+    # ------------------------------------------------------------------
+    @testset "US2: show(MIME\"text/latex\", ifactor(360))" begin
+        s = sprint(show, MIME("text/latex"), ifactor(360))
+        @test startswith(s, "\$\$")
+        @test endswith(s, "\$\$")
+        @test occursin("2^{3}", s)
+        @test occursin("3^{2}", s)
+        @test !occursin("360", s)
+    end
+
+    # ------------------------------------------------------------------
+    # US3: mathml gets the same treatment
+    # ------------------------------------------------------------------
+    @testset "US3: mathml(ifactor(360))" begin
+        ml = string(invoke_cmd(:mathml, ifactor(360)))
+        @test occursin("<mn>3</mn>", ml)
+        @test !occursin("<mn>360</mn>", ml)
+    end
+
+    # ------------------------------------------------------------------
+    # US4: no regression for ordinary expressions
+    # ------------------------------------------------------------------
+    @testset "US4: symbolic expressions unchanged" begin
+        x = giac_eval("x")
+        @test string(invoke_cmd(:latex, x^2 + 1)) == "\"x^{2}+1\""
+        @test occursin("\\frac", string(invoke_cmd(:latex, giac_eval("1/(1-x)"))))
+        @test occursin("\\sqrt", string(invoke_cmd(:latex, giac_eval("sqrt(2)"))))
+        @test occursin("\\sin", string(invoke_cmd(:latex, giac_eval("sin(x)"))))
+    end
+
+    @testset "US4: numbers and lists unchanged" begin
+        @test string(invoke_cmd(:latex, giac_eval("360"))) == "\"360\""
+        @test string(invoke_cmd(:latex, giac_eval("1/2"))) == "\"\\frac{1}{2}\""
+        # Plain Julia arguments never go through quoting
+        @test string(invoke_cmd(:latex, 360)) == "\"360\""
+        @test occursin("360", string(invoke_cmd(:latex, "360")))
+    end
+
+    @testset "US4: matrices unchanged" begin
+        tex = string(invoke_cmd(:latex, giac_eval("[[1,2],[3,4]]")))
+        @test occursin("array", tex)
+        @test occursin("1", tex) && occursin("4", tex)
+
+        M = GiacMatrix([1 2; 3 4])
+        s = sprint(show, MIME("text/latex"), M)
+        @test occursin("array", s)
+    end
+
+    @testset "US4: equations unchanged" begin
+        tex = string(invoke_cmd(:latex, giac_eval("x^2=4")))
+        @test occursin("x^{2}", tex)
+        @test occursin("4", tex)
+    end
+end


### PR DESCRIPTION
## Problem

Reported by @kahliburke: `latex` on an `ifactor` result loses the factorization.

```julia
julia> using Giac.Commands: ifactor, latex

julia> ifactor(360)
GiacExpr: 2^3*3^2*5

julia> latex(ifactor(360))
GiacExpr: "360"          # ← expected 5\cdot 2^{3}\cdot 3^{2}
```

The same happened in notebook display: an `ifactor` result rendered as `360` in
any frontend consuming the `text/latex` MIME type (Pluto, Jupyter, KaimonSlate).

## Root cause

GIAC evaluates the arguments of every command, and not every result is a fixed
point of evaluation. `ifactor(360)` is the *product* `2^3*3^2*5`, which
evaluates straight back to `360` — so the form was gone before `latex` could
typeset it.

This is why `giac_eval("latex(ifactor(360))")` always worked (a single
evaluation pass; `latex` prints the resulting gen) while `latex(f)` on an
already-computed `GiacExpr` did not (the second pass collapses it).

`mathml` had the identical bug.

## Fix

`invoke_cmd` now wraps the `GiacExpr` arguments of rendering commands in GIAC's
`quote(...)`, built with `make_symbolic_unevaluated`:

```julia
const RENDER_COMMANDS = (:latex, :mathml)
```

It works on both `invoke_cmd` dispatch paths — the direct-`Gen` fast path hands
the quoted `Gen` to `apply_func1`, and the string path prints it as
`'2^3*3^2*5'`, which the GIAC parser reads back as a quoted expression. Every
other command keeps GIAC's normal evaluation semantics; only `latex` and
`mathml` hold their argument, because they are the ones whose job is to show an
expression rather than compute with it.

```julia
julia> latex(ifactor(360))
GiacExpr: "5\cdot 2^{3}\cdot 3^{2}"

julia> sprint(show, MIME("text/latex"), ifactor(360))
"\$\$5\\cdot 2^{3}\\cdot 3^{2}\$\$"
```

## Tests

New `test/test_latex_render.jl` (41 tests, written before the fix — 22
failed/errored on the unpatched code, all pass after):

- the reported case, `Commands.latex`, `show(MIME"text/latex")`, `mathml`
- string-path/fast-path parity via `GIAC_INVOKE_CMD_STRING_PATH`
- regressions: symbolic expressions, numbers, fractions, lists, matrices,
  `GiacMatrix` display and equations render exactly as before

Full suite: 9249 pass, 2 pre-existing broken, Aqua clean. Docs rebuilt with no
new warnings.

## Docs

- new "Rendering preserves the expression you computed" section in
  `docs/src/pluto.md`
- rendering-commands note in the `invoke_cmd` docstring
- `Giac.RENDER_COMMANDS` added to the API reference
- `### Fixed` entry under `[Unreleased]` in `CHANGELOG.md`

No version bump — that happens in the separate `chore: release` commit.

---

AI assistance was used for this change.