### PR TITLE
feat: implement TermInterface head and children for GiacExpr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`GiacTermInterfaceExt` now implements `head` and `children`**, completing
+  the TermInterface protocol. TermInterface's `iscall` docstring makes them
+  mandatory — *"If `iscall(x)` is true, then also `isexpr(x)` must be true.
+  […] This means that, `head(x)` and `children(x)` must be defined. Together
+  with `operation(x)` and `arguments(x)."* — but the extension defined only
+  `iscall`/`isexpr`/`operation`/`arguments`/`maketerm`, so a consumer written
+  against the protocol's documented spelling hit a `MethodError` exactly where
+  `operation`/`arguments` would have answered.
+
+  Giac is a language in which every expression node is a function call, so the
+  two spellings coincide: `head` is `operation` and `children` is `arguments`.
+  `sorted_children` needs no method — TermInterface defaults it to `children`,
+  and Giac stores its arguments in order. On a leaf, where `isexpr` is false
+  and the protocol requires nothing, `head`/`children` raise the same
+  `ArgumentError` that `operation`/`arguments` raise rather than inventing a
+  head for a node that has none. Closes
+  [#41](https://github.com/s-celles/Giac.jl/issues/41).
+
+- **A documentation page for the TermInterface extension**
+  (`docs/src/extensions/terminterface.md`), which the extension previously
+  lacked. It documents the protocol table and calls out a trap for anyone
+  writing a traversal: a Giac numeric literal is a `GiacExpr`, **not** a
+  `Number` — `giac_eval("42") isa Number` is `false`, and `to_julia` is what
+  unwraps it — so a walk over `Number` / symbol / call looks exhaustive while
+  silently dropping every literal. Dispatch on `isexpr` instead. The same
+  shape caught SymbolicUtils.jl
+  ([JuliaSymbolics/SymbolicUtils.jl#1024](https://github.com/JuliaSymbolics/SymbolicUtils.jl/issues/1024)).
+  The caveat is repeated in the extension module's own header comment.
+
 ## [0.14.2] - 2026-07-24
 
 ### Fixed

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -43,6 +43,7 @@ _pages = [
          "Symbolics.jl" => "extensions/symbolics.md",
          "MathJSON.jl" => "extensions/mathjson.md",
          "MCP Server" => "extensions/mcp.md",
+         "TermInterface.jl" => "extensions/terminterface.md",
     ],
     "Developer Guide" => [
         "Overview" => "developer/index.md",

--- a/docs/src/extensions/terminterface.md
+++ b/docs/src/extensions/terminterface.md
@@ -1,0 +1,97 @@
+# TermInterface.jl Integration
+
+Giac.jl implements [TermInterface.jl](https://github.com/JuliaSymbolics/TermInterface.jl)'s
+expression protocol for `GiacExpr`, so packages built on it —
+[Metatheory.jl](https://github.com/JuliaSymbolics/Metatheory.jl),
+[SymbolicUtils.jl](https://github.com/JuliaSymbolics/SymbolicUtils.jl), and
+anything else that speaks the protocol — can traverse and rewrite Giac
+expressions as syntax trees.
+
+It is an optional package extension: it loads as soon as `TermInterface` is in
+scope, and costs nothing otherwise.
+
+```julia
+using Giac, TermInterface
+
+@giac_var x
+e = sin(x + 1)
+
+iscall(e)       # true
+operation(e)    # sin
+arguments(e)    # GiacExpr[x+1]
+head(e)         # sin
+children(e)     # GiacExpr[x+1]
+```
+
+## The protocol, as Giac implements it
+
+| TermInterface | `GiacExpr` behaviour |
+|---|---|
+| `isexpr(g)` | `true` for a function-call node, `false` for a leaf |
+| `iscall(g)` | same as `isexpr` — see below |
+| `head(g)` | the called function; same as `operation` |
+| `children(g)` | the arguments; same as `arguments` |
+| `operation(g)` | the called function, resolved in `Giac.Commands`, `Giac`, `Base` or `LinearAlgebra` |
+| `arguments(g)` | `Vector{GiacExpr}` of the operands |
+| `sorted_children(g)` | TermInterface's default, which forwards to `children` |
+| `maketerm(GiacExpr, op, args)` | rebuilds an expression from an operation and its arguments |
+
+Giac is a language in which **every expression node is a function call**, so
+`head`/`children` and `operation`/`arguments` coincide, and `isexpr` and
+`iscall` agree. TermInterface's own documentation names this case: the two
+spellings diverge only in languages that do not represent a call in their
+head, such as Julia's `Expr(:call, :f, :x)`, whose `head` is `:call` while its
+`operation` is `:f`.
+
+On a leaf — an identifier, a literal, a constant — `isexpr` is `false`, so the
+protocol does not require `head`/`children` to answer. They raise an
+`ArgumentError`, exactly as `operation`/`arguments` do, rather than inventing a
+head for a node that has none.
+
+```julia
+julia> head(giac_eval("x"))
+ERROR: ArgumentError: expression is not a function call
+```
+
+## Writing a traversal: literals are not `Number`s
+
+A Giac numeric literal is a `GiacExpr`, **not** a `Number`:
+
+```julia
+julia> giac_eval("42") isa Number
+false
+
+julia> to_julia(giac_eval("42"))
+42
+```
+
+A walk written over the three cases `Number` / symbol / call therefore *looks*
+exhaustive while silently dropping every literal. Dispatch on `isexpr` (or
+`iscall`) and treat whatever is left as a leaf, unwrapping it with `to_julia`:
+
+```julia
+using Giac, TermInterface
+
+function leaves(e)
+    isexpr(e) || return [to_julia(e)]
+    return reduce(vcat, leaves(c) for c in children(e))
+end
+
+leaves(giac_eval("2*x+3"))   # Any[2, x, 3] — the literals are there
+```
+
+The same shape caught SymbolicUtils.jl; see
+[JuliaSymbolics/SymbolicUtils.jl#1024](https://github.com/JuliaSymbolics/SymbolicUtils.jl/issues/1024).
+
+## Rebuilding expressions
+
+`maketerm` closes the loop, so a rewrite can put a tree back together:
+
+```julia
+using Giac, TermInterface
+
+@giac_var x
+e = sin(x + 1)
+rebuilt = maketerm(GiacExpr, operation(e), Tuple(arguments(e)))
+string(rebuilt) == string(e)   # true
+```

--- a/docs/src/llms-full.txt
+++ b/docs/src/llms-full.txt
@@ -4988,7 +4988,7 @@ You install it explicitly when (and only when) you want the MCP server.
 ```julia
 using Giac, ModelContextProtocol
 
-server = giac_mcp_server()   # construct the server (no I/O yet)
+server = Giac.giac_mcp_server()   # construct the server (no I/O yet)
 start!(server)                # blocks on STDIO transport
 ```
 
@@ -5032,7 +5032,7 @@ equivalent) and add a `mcpServers` entry:
       "args": [
         "--project=/path/to/env",
         "-e",
-        "using Giac, ModelContextProtocol; start!(giac_mcp_server())"
+        "using Giac, ModelContextProtocol; start!(Giac.giac_mcp_server())"
       ]
     }
   }
@@ -5047,7 +5047,7 @@ as quickly as Julia allows. Restart Claude Desktop after editing the config.
 ## Setup with Claude Code
 
 ```bash
-claude mcp add-json "giac-cas" '{"command":"julia","args":["--project=/path/to/env","-e","using Giac, ModelContextProtocol; start!(giac_mcp_server())"]}'
+claude mcp add-json "giac-cas" '{"command":"julia","args":["--project=/path/to/env","-e","using Giac, ModelContextProtocol; start!(Giac.giac_mcp_server())"]}'
 ```
 
 Confirm with `claude mcp list`. From any Claude Code session, ask:
@@ -5071,7 +5071,7 @@ To verify the server end-to-end without an LLM client:
 printf '%s\n%s\n' \
   '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}},"id":1}' \
   '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"giac_eval","arguments":{"expr":"factor(x^4-1)"}},"id":2}' \
-| julia --project -e 'using Giac, ModelContextProtocol; start!(giac_mcp_server())' \
+| julia --project -e 'using Giac, ModelContextProtocol; start!(Giac.giac_mcp_server())' \
   2>/dev/null | jq .
 ```
 
@@ -5147,7 +5147,7 @@ Use the `giac_search` tool when you don't remember the exact command name:
 ## API reference
 
 ```@docs
-giac_mcp_server
+Giac.giac_mcp_server
 ```
 
 ## Limitations and future work
@@ -5164,6 +5164,110 @@ The first release is intentionally minimal. Deferred to later iterations:
   Each tool call is currently independent.
 - A **`PackageCompiler.jl` sysimage** to reduce Julia's startup latency
   when an LLM client launches the server as a subprocess.
+
+
+---
+
+## Section: TermInterface.jl
+<!-- Source: extensions/terminterface.md -->
+
+# TermInterface.jl Integration
+
+Giac.jl implements [TermInterface.jl](https://github.com/JuliaSymbolics/TermInterface.jl)'s
+expression protocol for `GiacExpr`, so packages built on it —
+[Metatheory.jl](https://github.com/JuliaSymbolics/Metatheory.jl),
+[SymbolicUtils.jl](https://github.com/JuliaSymbolics/SymbolicUtils.jl), and
+anything else that speaks the protocol — can traverse and rewrite Giac
+expressions as syntax trees.
+
+It is an optional package extension: it loads as soon as `TermInterface` is in
+scope, and costs nothing otherwise.
+
+```julia
+using Giac, TermInterface
+
+@giac_var x
+e = sin(x + 1)
+
+iscall(e)       # true
+operation(e)    # sin
+arguments(e)    # GiacExpr[x+1]
+head(e)         # sin
+children(e)     # GiacExpr[x+1]
+```
+
+## The protocol, as Giac implements it
+
+| TermInterface | `GiacExpr` behaviour |
+|---|---|
+| `isexpr(g)` | `true` for a function-call node, `false` for a leaf |
+| `iscall(g)` | same as `isexpr` — see below |
+| `head(g)` | the called function; same as `operation` |
+| `children(g)` | the arguments; same as `arguments` |
+| `operation(g)` | the called function, resolved in `Giac.Commands`, `Giac`, `Base` or `LinearAlgebra` |
+| `arguments(g)` | `Vector{GiacExpr}` of the operands |
+| `sorted_children(g)` | TermInterface's default, which forwards to `children` |
+| `maketerm(GiacExpr, op, args)` | rebuilds an expression from an operation and its arguments |
+
+Giac is a language in which **every expression node is a function call**, so
+`head`/`children` and `operation`/`arguments` coincide, and `isexpr` and
+`iscall` agree. TermInterface's own documentation names this case: the two
+spellings diverge only in languages that do not represent a call in their
+head, such as Julia's `Expr(:call, :f, :x)`, whose `head` is `:call` while its
+`operation` is `:f`.
+
+On a leaf — an identifier, a literal, a constant — `isexpr` is `false`, so the
+protocol does not require `head`/`children` to answer. They raise an
+`ArgumentError`, exactly as `operation`/`arguments` do, rather than inventing a
+head for a node that has none.
+
+```julia
+julia> head(giac_eval("x"))
+ERROR: ArgumentError: expression is not a function call
+```
+
+## Writing a traversal: literals are not `Number`s
+
+A Giac numeric literal is a `GiacExpr`, **not** a `Number`:
+
+```julia
+julia> giac_eval("42") isa Number
+false
+
+julia> to_julia(giac_eval("42"))
+42
+```
+
+A walk written over the three cases `Number` / symbol / call therefore *looks*
+exhaustive while silently dropping every literal. Dispatch on `isexpr` (or
+`iscall`) and treat whatever is left as a leaf, unwrapping it with `to_julia`:
+
+```julia
+using Giac, TermInterface
+
+function leaves(e)
+    isexpr(e) || return [to_julia(e)]
+    return reduce(vcat, leaves(c) for c in children(e))
+end
+
+leaves(giac_eval("2*x+3"))   # Any[2, x, 3] — the literals are there
+```
+
+The same shape caught SymbolicUtils.jl; see
+[JuliaSymbolics/SymbolicUtils.jl#1024](https://github.com/JuliaSymbolics/SymbolicUtils.jl/issues/1024).
+
+## Rebuilding expressions
+
+`maketerm` closes the loop, so a rewrite can put a tree back together:
+
+```julia
+using Giac, TermInterface
+
+@giac_var x
+e = sin(x + 1)
+rebuilt = maketerm(GiacExpr, operation(e), Tuple(arguments(e)))
+string(rebuilt) == string(e)   # true
+```
 
 
 ---

--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -29,6 +29,7 @@
 - [Symbolics.jl](extensions/symbolics.html)
 - [MathJSON.jl](extensions/mathjson.html)
 - [MCP Server](extensions/mcp.html)
+- [TermInterface.jl](extensions/terminterface.html)
 - [Overview](developer/index.html)
 - [Package Architecture](developer/architecture.html)
 - [Performance Tiers](developer/tier-system.html)

--- a/ext/GiacTermInterfaceExt.jl
+++ b/ext/GiacTermInterfaceExt.jl
@@ -1,14 +1,22 @@
 # Extension module for TermInterface.jl integration.
 #
-# Implements TermInterface's iscall / operation / arguments / maketerm methods
-# for `GiacExpr`, so that downstream packages built on TermInterface
-# (Metatheory.jl, SymbolicUtils.jl, …) can traverse and rewrite Giac
-# expressions as syntax trees.
+# Implements TermInterface's isexpr / head / children / iscall / operation /
+# arguments / maketerm methods for `GiacExpr`, so that downstream packages
+# built on TermInterface (Metatheory.jl, SymbolicUtils.jl, …) can traverse and
+# rewrite Giac expressions as syntax trees.
 #
 # The core methods are defined in `Giac` itself (introspection.jl) so that
 # `Giac.iscall(expr)` etc. always work without an extra dependency. This
 # extension just bridges those into TermInterface's namespace when the user
 # has TermInterface loaded.
+#
+# TRAVERSAL CAVEAT. A Giac numeric literal is a `GiacExpr`, not a `Number`:
+# `giac_eval("42") isa Number` is `false`, and `to_julia` is what unwraps it.
+# A walk written over the three cases Number / symbol / call therefore *looks*
+# exhaustive while silently dropping every literal. Dispatch on `isexpr` (or
+# `iscall`) and treat whatever is left as a leaf, unwrapping it with
+# `to_julia`. The same shape bit SymbolicUtils.jl — see
+# JuliaSymbolics/SymbolicUtils.jl#1024.
 
 module GiacTermInterfaceExt
 
@@ -24,6 +32,28 @@ TermInterface.arguments(g::GiacExpr)::Vector{GiacExpr} = Giac.arguments(g)
 # `iscall` and `isexpr` typically agree for languages without explicit
 # `term`-vs-`call` distinction. Giac doesn't carry that distinction either.
 TermInterface.isexpr(g::GiacExpr)::Bool = Giac.iscall(g)
+
+# `head`/`children` are not optional. TermInterface's `iscall` docstring
+# requires them wherever `isexpr` is true, and without them a consumer written
+# against the protocol's documented spelling hit a `MethodError` exactly where
+# `operation`/`arguments` would have answered (issue #41).
+#
+# Giac is a language in which every expression node is a function call, so the
+# two spellings coincide — the case TermInterface's own docstring describes for
+# SymbolicUtils-like languages, as against `Expr(:call, :f, :x)` whose `head`
+# is `:call` while its `operation` is `:f`.
+#
+# On a leaf — an identifier, a literal, a constant — `isexpr` is false, so the
+# protocol does not require these to answer. They raise the same
+# `ArgumentError` that `operation`/`arguments` raise rather than inventing a
+# head for a node that has none.
+#
+# `sorted_children` needs no method here: TermInterface defaults it to
+# `children`, and Giac stores its arguments in order, so the default already
+# gives the deterministic answer that spelling promises.
+TermInterface.head(g::GiacExpr) = Giac.operation(g)
+
+TermInterface.children(g::GiacExpr)::Vector{GiacExpr} = Giac.arguments(g)
 
 # Reconstruct an expression from an op + args. Mirrors the in-core helper.
 TermInterface.maketerm(::Type{<:GiacExpr}, op, args, metadata=nothing)::GiacExpr =

--- a/test/test_terminterface_ext.jl
+++ b/test/test_terminterface_ext.jl
@@ -74,4 +74,90 @@ using TermInterface
         rebuilt = TermInterface.maketerm(GiacExpr, op, Tuple(args))
         @test string(rebuilt) == string(original)
     end
+
+    # ========================================================================
+    # head / children (Issue #41)
+    #
+    # TermInterface's `iscall` docstring makes these mandatory: "If `iscall(x)`
+    # is true, then also `isexpr(x)` *must* be true. […] This means that,
+    # `head(x)` and `children(x)` must be defined. Together with `operation(x)`
+    # and `arguments(x)`." A consumer written against the protocol's documented
+    # spelling previously hit a MethodError where operation/arguments worked.
+    #
+    # Giac is a language in which every expression node is a function call, so
+    # the two spellings coincide — as TermInterface's own docstring
+    # anticipates for SymbolicUtils-like languages.
+    # ========================================================================
+
+    @testset "head and children" begin
+        @testset "defined wherever isexpr is true" begin
+            for e in (sin(x), x + y, x * y, giac_eval("a*b*c"), sin(x + 1))
+                @test TermInterface.isexpr(e)
+                @test TermInterface.head(e) === TermInterface.operation(e)
+                @test TermInterface.children(e) == TermInterface.arguments(e)
+            end
+        end
+
+        @testset "the iscall => isexpr implication holds" begin
+            for e in (
+                sin(x),
+                x + y,
+                x,
+                giac_eval("1"),
+                giac_eval("pi"),
+                giac_eval("42"),
+                giac_eval("[1,2,3]"),
+            )
+                TermInterface.iscall(e) && @test TermInterface.isexpr(e)
+            end
+        end
+
+        @testset "concrete heads and children" begin
+            @test TermInterface.head(sin(x)) === sin
+            @test TermInterface.head(x + y) === +
+            @test TermInterface.head(x * y) === *
+            @test TermInterface.children(sin(x)) == [x]
+            @test length(TermInterface.children(x + y)) == 2
+            @test length(TermInterface.children(giac_eval("a*b*c"))) == 3
+            @test TermInterface.children(sin(x)) isa Vector{GiacExpr}
+        end
+
+        @testset "sorted_children follows children" begin
+            # TermInterface defaults `sorted_children` to `children`; Giac
+            # stores its arguments in order, so the default is correct and a
+            # consumer that asks for the deterministic spelling gets it.
+            e = giac_eval("a*b*c")
+            @test TermInterface.sorted_children(e) == TermInterface.children(e)
+        end
+
+        @testset "leaves have no head or children" begin
+            # `isexpr` is false for these, so the protocol does not require
+            # head/children to answer — and they must not answer silently
+            # wrong. They raise, exactly as operation/arguments do.
+            for leaf in (x, giac_eval("42"), giac_eval("pi"))
+                @test !TermInterface.isexpr(leaf)
+                @test_throws ArgumentError TermInterface.head(leaf)
+                @test_throws ArgumentError TermInterface.children(leaf)
+            end
+        end
+
+        @testset "a head/children traversal reaches literals" begin
+            # The trap the issue calls out: a Giac numeric literal is a
+            # `GiacExpr`, not a `Number`, so a walk written over
+            # Number/symbol/call looks exhaustive but silently drops literals.
+            # `to_julia` is what unwraps them.
+            lit = giac_eval("42")
+            @test !(lit isa Number)
+            @test to_julia(lit) === 42
+
+            leaves = Any[]
+            walk(e) =
+                TermInterface.isexpr(e) ? foreach(walk, TermInterface.children(e)) :
+                push!(leaves, e)
+            walk(giac_eval("2*x+3"))
+            @test any(l -> to_julia(l) === 2, leaves)
+            @test any(l -> to_julia(l) === 3, leaves)
+            @test any(l -> string(l) == "x", leaves)
+        end
+    end
 end


### PR DESCRIPTION
Closes #41.

`GiacTermInterfaceExt` implemented `iscall`/`isexpr`/`operation`/`arguments`/`maketerm` but not `head`/`children`, which TermInterface's own `iscall` docstring makes mandatory:

> If `iscall(x)` is true, then also `isexpr(x)` *must* be true. […] This means that, `head(x)` and `children(x)` must be defined. Together with `operation(x)` and `arguments(x)`.

So a consumer written against the protocol's documented spelling hit a `MethodError` exactly where `operation`/`arguments` would have answered.

### Before / after

```
symbol   iscall=false  isexpr=false  head=MethodError    children=MethodError
literal  iscall=false  isexpr=false  head=MethodError    children=MethodError
call     iscall=true   isexpr=true   head=MethodError    children=MethodError
```
```
symbol   iscall=false  isexpr=false  head=ArgumentError  children=ArgumentError
literal  iscall=false  isexpr=false  head=ArgumentError  children=ArgumentError
call     iscall=true   isexpr=true   head=+              children=2
```

### Design notes

Giac is a language in which every expression node is a function call, so the two spellings coincide: `head` is `operation`, `children` is `arguments`. This is the case TermInterface's docstring describes for SymbolicUtils-like languages, as against `Expr(:call, :f, :x)` whose `head` is `:call` while its `operation` is `:f`.

- **`sorted_children` needs no method.** TermInterface defaults it to `children`, and Giac stores its arguments in order, so the default is already the deterministic answer that spelling promises. Asserted by a test rather than left implicit.
- **Leaves raise rather than answer.** `isexpr` is `false` for an identifier, literal or constant, so the protocol requires nothing there; `head`/`children` raise the same `ArgumentError` that `operation`/`arguments` already raise, instead of inventing a head for a node that has none.

### Also included

The extension had no documentation page, so this adds `docs/src/extensions/terminterface.md`: the protocol table, the `head`-vs-`operation` distinction, `maketerm`, and the traversal trap the issue calls out — a Giac numeric literal is a `GiacExpr`, **not** a `Number`, so a walk over `Number` / symbol / call looks exhaustive while silently dropping every literal. Dispatch on `isexpr` and unwrap leaves with `to_julia`. Same shape as JuliaSymbolics/SymbolicUtils.jl#1024. The caveat is repeated in the extension's header comment.

### Testing

Written test-first: 6 failures + 19 errors before the fix, 58/58 after. Covers the `iscall ⟹ isexpr` implication over calls and leaves, `head === operation` / `children == arguments` across a corpus, `sorted_children` agreement, the leaf refusals, and a traversal that walks `2*x+3` via `isexpr`/`children` and asserts the literals `2` and `3` actually arrive.

Full suite: 9288 pass, 2 pre-existing broken, Aqua 10/10. Docs build with no new warnings.

---

**Part 1 of 3 in a stack.** Merge this first; #43 and #44 sit on top.