### PR TITLE
feat: a LibPARI.jl bridge as an optional extension

### DIFF
--- a/.github/workflows/CI-LibPARI.yml
+++ b/.github/workflows/CI-LibPARI.yml
@@ -1,0 +1,67 @@
+name: CI (LibPARI bridge)
+
+# The LibPARI.jl bridge gets its own job rather than a place in the main
+# matrix. Two reasons:
+#
+#   * Attribution. A failure here says "the bridge broke", not "one of the six
+#     main-matrix cells broke somewhere in a 3000-assertion suite".
+#   * Isolation. This job builds a project containing *only* Giac and LibPARI,
+#     so it fails if the bridge ever comes to depend on another extension
+#     having loaded first — something the full test run, which loads
+#     Symbolics, MathJSON, TermInterface and the MCP server, cannot detect.
+#
+# The bridge is also covered by the main matrix via the `test` target; this
+# job is the signal, not the only coverage.
+
+on:
+  push:
+    branches:
+      - main
+      - 'release-*'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  libpari-bridge:
+    name: LibPARI bridge - Julia ${{ matrix.version }} - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.10'  # LTS
+          - '1'     # Latest stable
+        os:
+          - ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+          arch: x64
+      - uses: julia-actions/cache@v2
+      - name: Build a project holding only Giac and LibPARI
+        run: |
+          mkdir -p bridge-env
+          julia --project=bridge-env -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path = pwd()))
+            Pkg.add("LibPARI")
+            Pkg.instantiate()
+            Pkg.status()'
+      - name: Assert the extension is loaded
+        run: |
+          julia --project=bridge-env -e '
+            using Giac, LibPARI
+            ext = Base.get_extension(Giac, :GiacLibPARIExt)
+            ext === nothing && error("GiacLibPARIExt did not load")
+            @info "GiacLibPARIExt loaded" ext'
+      - name: Run the bridge tests standalone
+        run: julia --project=bridge-env test/test_libpari_ext.jl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,24 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   combination that is unsatisfiable and that no user encounters, since one
   loads a single extension rather than five floor-pinned ones together.
 
-### Fixed
-
-- **Two `[compat]` lower bounds were unsatisfiable**, found by the new
-  downgrade job on its first run:
-
-  - `GIAC_jll = "2"` claimed support for 2.0.0, but `libgiac_julia_jll` 0.5
-    requires `GIAC_jll >= 2.0.1`, so that floor could never resolve. Now
-    `"2.0.1"`.
-  - `CxxWrap = "0.16, 0.17"` claimed support for 0.16, but CxxWrap 0.16
-    requires `libcxxwrap_julia_jll` 0.13 while this package pins 0.14.9, so
-    0.16 could never resolve either. Now `"0.17"`.
-
-  Neither is a functional narrowing — no user could have been resolved onto
-  those versions; the bounds simply described versions that do not work. With
-  them corrected, the full suite passes at the floors on Julia 1.10.
-
-### Added
-
 - **`GiacTermInterfaceExt` now implements `head` and `children`**, completing
   the TermInterface protocol. TermInterface's `iscall` docstring makes them
   mandatory — *"If `iscall(x)` is true, then also `isexpr(x)` must be true.
@@ -80,7 +62,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([JuliaSymbolics/SymbolicUtils.jl#1024](https://github.com/JuliaSymbolics/SymbolicUtils.jl/issues/1024)).
   The caveat is repeated in the extension module's own header comment.
 
+- **LibPARI.jl bridge**: values can now cross between Giac and
+  [PARI/GP](https://pari.math.u-bordeaux.fr/) through a new weak-dependency
+  package extension `GiacLibPARIExt` on
+  [`LibPARI.jl`](https://github.com/s-celles/LibPARI.jl) 0.17. Two entry
+  points, one per direction: `to_giac(g::LibPARI.Gen)` outward and a method
+  on LibPARI's own `pari(e::GiacExpr)` inward — no second inward name. The
+  bridge is hosted here rather than in LibPARI.jl because hosting means
+  paying the CI cost, and `PARI_jll` (19 MB, ~13 dependencies) is far cheaper
+  for Giac.jl to pull than `GIAC_jll` (73 MB, ~56 dependencies) would be the
+  other way round.
+
+  The bridge is **value-preserving and name-preserving, not
+  representation-preserving**: PARI's variable priority is process-global and
+  Giac orders by its own rules, so round trips are compared with `==` (PARI's
+  `gequal`) and never with `string`. It covers `T_INT`, `T_FRAC`, `T_REAL`,
+  `T_COMPLEX`, `T_POL`, `T_VEC`, `T_COL`, `T_VECSMALL`, `T_LIST` and `T_MAT`
+  outward, and `INT`, `ZINT`, `FRAC`, `DOUBLE`, `REAL`, `CPLX`, `IDNT`,
+  polynomial `SYMB` and `VECT` inward. Everything else is refused with an
+  `ArgumentError` that names the tag it could not translate.
+
+  Reals cross carrying the *value's* own precision rather than the ambient
+  `setprecision(LibPARI.Gen, …)` setting, and never through a printed decimal
+  — injecting a PARI real into GP as text silently truncates a 512-bit value
+  to 128 bits. Known limitations (`T_COL`/`T_VECSMALL`/`T_LIST` widening to
+  `T_VEC`, float tags not surviving, `MOD` and string types refused) are
+  documented in `docs/src/extensions/libpari.md` and each is pinned by a test.
+
+  The bridge has a dedicated CI job that runs its tests against a project
+  containing only Giac and LibPARI, so a bridge failure is attributable and
+  an accidental dependence on another extension would be caught.
+
 ### Fixed
+
+- **Two `[compat]` lower bounds were unsatisfiable**, found by the new
+  downgrade job on its first run:
+
+  - `GIAC_jll = "2"` claimed support for 2.0.0, but `libgiac_julia_jll` 0.5
+    requires `GIAC_jll >= 2.0.1`, so that floor could never resolve. Now
+    `"2.0.1"`.
+  - `CxxWrap = "0.16, 0.17"` claimed support for 0.16, but CxxWrap 0.16
+    requires `libcxxwrap_julia_jll` 0.13 while this package pins 0.14.9, so
+    0.16 could never resolve either. Now `"0.17"`.
+
+  Neither is a functional narrowing — no user could have been resolved onto
+  those versions; the bounds simply described versions that do not work. With
+  them corrected, the full suite passes at the floors on Julia 1.10.
 
 - **`to_julia` on a `STRNG` now returns the characters, not GIAC's printed
   literal.** `to_julia(giac_eval("\"hello\""))` answered `"\"hello\""` — the

--- a/Project.toml
+++ b/Project.toml
@@ -14,12 +14,14 @@ libcxxwrap_julia_jll = "3eaa8342-bff7-56a5-9981-c04077f7cee7"
 libgiac_julia_jll = "ec39d2da-6bdf-580b-ada4-cd6e059515c9"
 
 [weakdeps]
+LibPARI = "75bc234d-eb99-4f80-8816-cb1dc773483e"
 MathJSON = "77215b4b-6f01-425c-beac-950ae6536d4d"
 ModelContextProtocol = "c58f755f-f2a7-4f48-bf29-4e9659b78499"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 TermInterface = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
 
 [extensions]
+GiacLibPARIExt = "LibPARI"
 GiacMCPExt = "ModelContextProtocol"
 GiacMathJSONExt = "MathJSON"
 GiacSymbolicsExt = "Symbolics"
@@ -34,6 +36,7 @@ DataFrames = "1.6, 1.7, 1.8"
 Documenter = "1"
 ForwardDiff = "0.10, 1"
 GIAC_jll = "2.0.1"
+LibPARI = "0.17"
 Libdl = "1.10"
 LinearAlgebra = "1.10"
 MathJSON = "0.2, 0.3"
@@ -53,6 +56,7 @@ CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+LibPARI = "75bc234d-eb99-4f80-8816-cb1dc773483e"
 MathJSON = "77215b4b-6f01-425c-beac-950ae6536d4d"
 ModelContextProtocol = "c58f755f-f2a7-4f48-bf29-4e9659b78499"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -61,4 +65,4 @@ TermInterface = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Aqua", "Documenter", "Symbolics", "MathJSON", "ModelContextProtocol", "DataFrames", "CSV", "TermInterface", "Random", "ForwardDiff"]
+test = ["Test", "Aqua", "Documenter", "Symbolics", "MathJSON", "ModelContextProtocol", "DataFrames", "CSV", "TermInterface", "Random", "ForwardDiff", "LibPARI"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -44,6 +44,7 @@ _pages = [
          "MathJSON.jl" => "extensions/mathjson.md",
          "MCP Server" => "extensions/mcp.md",
          "TermInterface.jl" => "extensions/terminterface.md",
+         "LibPARI.jl" => "extensions/libpari.md",
     ],
     "Developer Guide" => [
         "Overview" => "developer/index.md",

--- a/docs/src/extensions/libpari.md
+++ b/docs/src/extensions/libpari.md
@@ -1,0 +1,253 @@
+# LibPARI.jl Integration
+
+Giac.jl can exchange values with [LibPARI.jl](https://github.com/s-celles/LibPARI.jl),
+a Julia wrapper for the [PARI/GP](https://pari.math.u-bordeaux.fr/) computer
+algebra system. The bridge is an optional package extension: it becomes
+available as soon as both packages are loaded, and costs nothing otherwise.
+
+```julia
+using Giac, LibPARI
+
+to_giac(gp_eval("(w+x)^2"))     # PARI  -> Giac
+pari(giac_eval("x^2+1"))        # Giac  -> PARI
+```
+
+The bridge lives here, in Giac.jl, rather than in LibPARI.jl. Hosting a bridge
+means paying its CI cost, and `PARI_jll` (19 MB, ~13 Julia dependencies) is far
+cheaper for Giac.jl to pull than `GIAC_jll` (73 MB, ~56 dependencies) would be
+for LibPARI.jl.
+
+## Installation
+
+```julia
+using Pkg
+Pkg.add("Giac")
+Pkg.add("LibPARI")   # 0.17 or later
+```
+
+`LibPARI` is a weak dependency of Giac.jl, so nothing is installed until you
+ask for it. The extension loads automatically when both packages are in scope.
+
+## The two entry points
+
+There is exactly one function per direction, following the convention
+LibPARI's own Symbolics.jl bridge established.
+
+| Direction | Call | Owner of the name |
+|---|---|---|
+| PARI → Giac | `to_giac(g::LibPARI.Gen)` | Giac.jl |
+| Giac → PARI | `LibPARI.pari(e::GiacExpr)` | LibPARI.jl |
+
+The inward direction adds a method to LibPARI's own entry point rather than
+introducing a second name such as `to_pari`. That is not type piracy: LibPARI
+owns `pari`, Giac owns `GiacExpr`. One entry point, one contract.
+
+## The contract
+
+**The bridge is value-preserving and name-preserving. It is not
+representation-preserving.**
+
+A PARI polynomial carries a variable *number* whose *priority* is
+process-global. `varhigher` and `varlower` change that ordering for the whole
+process, so `(w+x)^2` prints as `x^2+2*w*x+w^2` or as `w^2+2*x*w+x^2`
+depending on which ordering is in force. Giac orders by its own rules. The
+variable *name* survives both crossings; the ordering does not.
+
+Consequently:
+
+* Compare round trips **by value**: `pari(to_giac(g)) == g`. On a `Gen`, `==`
+  is PARI's `gequal`.
+* **Never** compare by text: `string(x) == string(y)` is an assertion that
+  will be red or flaky, and the test suite contains no such comparison.
+
+```julia
+using Giac, LibPARI
+
+g = gp_eval("(w+x)^2")
+pari(to_giac(g)) == g        # true — this is the assertion to make
+string(pari(to_giac(g))) == string(g)   # do not rely on this
+```
+
+## Mapping table
+
+Both systems expose a runtime type tag — `LibPARI.gentype(g)` returns a
+`LibPARI.PariType`, `Giac.giac_type(e)` returns a `Giac.GenTypes.T`. The
+table below drives the implementation.
+
+### PARI → Giac (`to_giac`)
+
+| PARI tag | Giac tag | Route | Notes |
+|---|---|---|---|
+| `T_INT` | `INT` / `ZINT` | via `BigInt` | Giac picks the width |
+| `T_FRAC` | `FRAC` | via `Rational{BigInt}` | |
+| `T_REAL` | `REAL` / `DOUBLE` | via `BigFloat` | Giac picks the width by how much precision the value needs |
+| `T_COMPLEX` | `CPLX` | recurse on `real`/`imag` | |
+| `T_POL` | `SYMB` / `IDNT` / scalar | Horner over `gpolvar` | a degree-0 `t_POL` collapses to its constant, which is what PARI's own `==` compares it to |
+| `T_VEC` | `VECT` | elementwise | |
+| `T_COL` | `VECT` | elementwise | **widens** — see limitations |
+| `T_VECSMALL` | `VECT` | elementwise | **widens** |
+| `T_LIST` | `VECT` | elementwise | **widens** |
+| `T_MAT` | `VECT` of `VECT`, row-major | elementwise | `size(g)` reports Julia's `(rows, columns)`; PARI stores columns |
+| anything else | — | **refused, tag named** | |
+
+### Giac → PARI (`LibPARI.pari`)
+
+| Giac tag | PARI tag | Route | Notes |
+|---|---|---|---|
+| `INT` | `T_INT` | via `Int64` | |
+| `ZINT` | `T_INT` | via `BigInt` | |
+| `FRAC` | `T_FRAC` / `T_INT` | `numer`/`denom`, recursively | also covers Giac's habit of storing a complex number with rational parts as a `FRAC`, e.g. `(3+2*i)/4` |
+| `DOUBLE` | `T_REAL` | via `Float64` | PARI has no hardware-float tag |
+| `REAL` | `T_REAL` | via `BigFloat` | see [Reals and precision](@ref) |
+| `CPLX` | `T_COMPLEX` | recurse on real/imaginary part | |
+| `IDNT` | `T_POL` | the free symbol of that name | Giac constants such as `pi` are **refused** |
+| `SYMB` | `T_POL` | `symb2poly` + Horner | only when the expression is a polynomial in its free identifiers |
+| `VECT` (flat) | `T_VEC` | elementwise | |
+| `VECT` of equal-length `VECT`s | `T_MAT` | column by column | |
+| anything else | — | **refused, tag named** | |
+
+## What is refused, and why
+
+Every refusal raises an `ArgumentError` that **names the tag** it could not
+translate, so the message is actionable on its own.
+
+```julia
+julia> to_giac(gp_eval("3+O(5^4)"))
+ERROR: ArgumentError: to_giac: no Giac counterpart for the PARI tag T_PADIC;
+the bridge covers T_INT, T_FRAC, T_REAL, T_COMPLEX, T_POL, T_VEC, T_COL,
+T_VECSMALL, T_LIST and T_MAT
+
+julia> pari(giac_eval("sin(x)"))
+ERROR: ArgumentError: pari: no PARI counterpart for the Giac tag SYMB
+(`sin(x)` is not a polynomial in identifiers — Giac reports `sin(x)` as one of
+its variables); the bridge covers INT, ZINT, FRAC, DOUBLE, REAL, CPLX, IDNT,
+SYMB and VECT
+```
+
+| Refused | Direction | Reason |
+|---|---|---|
+| `T_INTMOD` / `MOD` | both | Giac's `MOD` is opaque to the public API: `op`, `left`, `right` and `feuille` all return the `MOD` itself, so the residue and the modulus cannot be recovered and the value could not come back. Giac also normalises to a symmetric representative — `5 % 7` becomes `-2 % 7` — so even the value is not stable. |
+| `T_STR` / `STRNG` | both | LibPARI exposes no accessor for the characters of a `t_STR` in its public API — `string(g)` returns the GP literal, quotes and escapes included, and reading the value back out of it is the text round trip this contract forbids. Giac's side is fine (`to_julia` on a `STRNG` returns the characters), but one working side is not enough for a round trip, and strings carry no mathematical content for a CAS bridge. If LibPARI gains a public accessor, this row can move to the supported table. |
+| `T_RFRAC`, and any Giac `SYMB` that is a rational function | both | PARI represents `1/(x+1)` as a `t_RFRAC`; the bridge covers polynomials only. `1/x` and `x/(x+1)` are detected through Giac's `denom`. |
+| `T_PADIC`, `T_QUAD`, `T_SER`, `T_POLMOD`, `T_CLOSURE`, … | outward | No Giac counterpart. |
+| Giac `SYMB` involving `sin`, `exp`, `sqrt`, … | inward | Not a polynomial. Giac's `lvar` reports each such subexpression as a generalised variable rather than as an identifier, which is exactly the test the bridge applies. |
+| Giac `IDNT` that is a constant (`pi`, `i`, …) | inward | A PARI variable named `pi` is not Giac's π, and inventing one would be wrong. |
+| A ragged or mixed Giac `VECT` | inward | PARI has no ragged container. Only a rectangular nesting maps onto a `t_MAT`. |
+| Giac `POLY`, `FUNC`, `MAP`, … | inward | No PARI counterpart. |
+
+## Reals and precision
+
+Precision is a scope. `setprecision(LibPARI.Gen, bits) do … end` sets
+LibPARI's working precision in bits, and it governs PARI *computations*.
+
+**The bridge does not consult it.** A real crosses carrying the precision of
+the value itself, in both directions — a 512-bit `t_REAL` reaches Giac with
+all 512 bits even while the ambient setting is 64, and comes back a 512-bit
+`t_REAL`.
+
+```julia
+using Giac, LibPARI
+
+wide = setprecision(() -> LibPARI.PARI.mppi(), LibPARI.Gen, 512)
+precision(wide)                                   # 512
+
+setprecision(LibPARI.Gen, 64) do
+    pari(to_giac(wide)) == wide                   # true
+end
+precision(pari(to_giac(wide)))                    # 512
+```
+
+### Why the bridge never routes a value through text
+
+Injecting a PARI real into GP as a decimal string turns a 512-bit real into a
+128-bit one, silently, because PARI prints at the current `realprecision`:
+
+```julia
+p = setprecision(() -> LibPARI.PARI.mppi(), LibPARI.Gen, 512)
+precision(p)                             # 512
+precision(gp_eval(string(p)))            # 128  — no error, no warning
+```
+
+Values therefore cross structurally, or through exact Julia values (`BigInt`,
+`Rational`, `BigFloat`) — never through `string`. `BigFloat(::Gen)` widens the
+working precision to hold the mantissa exactly, and `LibPARI.pari(::BigFloat)`
+rebuilds a `t_REAL` from the mantissa and exponent, so the PARI legs are exact
+by construction.
+
+### The one place text is unavoidable
+
+Reading a Giac `REAL` back out is the exception, and it is worth stating
+plainly. The libgiac wrapper exposes `to_double` — a `Float64`, and therefore
+lossy — and nothing for an MPFR value; reaching past it into an undeclared
+libgiac C symbol is a call this project does not make. Giac's printer does,
+however, emit a `REAL` at that value's *own* precision rather than at a global
+setting, so the decimal it produces is faithful and only the bit width has to
+be recovered.
+
+The bridge recovers that width by search and then **verifies** it: a candidate
+is accepted only when re-encoding it reproduces Giac's own printed form
+character for character. A width that cannot be verified raises rather than
+returning a quietly-rounded value. The behaviour is pinned by tests at 64,
+128, 192, 256, 384, 512 and 1024 bits.
+
+This would become unnecessary if the wrapper gained an MPFR accessor for
+`REAL`; until then it is the bridge's only text-mediated step, and it is
+checked rather than trusted.
+
+## Known limitations
+
+Each of these is pinned by a test, so a change in behaviour shows up in
+Giac.jl's suite rather than in your results.
+
+1. **`T_COL`, `T_VECSMALL` and `T_LIST` widen to `T_VEC`.** Giac has a single
+   vector type, so the container tag cannot survive. The elements do.
+
+   ```julia
+   g = gp_eval("[1,2,3]~")           # a t_COL
+   back = pari(to_giac(g))
+   back == gp_eval("[1,2,3]")        # true  — values preserved
+   LibPARI.gentype(back)             # T_VEC — tag not preserved
+   back == g                         # false
+   ```
+
+   If you need the round trip to be tag-exact, normalise on the PARI side
+   first with `Vec(...)`.
+
+2. **PARI's variable ordering does not cross**, as described under
+   [The contract](@ref). Compare by value.
+
+3. **Float tags are not preserved.** Giac's `DOUBLE` and `REAL` both land on
+   PARI's `t_REAL`; coming back, Giac picks `DOUBLE` or `REAL` according to
+   how much precision the value needs. Values are preserved either way.
+
+4. **A `Gen` is not a `Number`.** It is a `LibPARI.PariObject`. Generic
+   numeric code bounded by `T<:Number` will not accept one, and `Number`
+   methods must not be assumed to apply.
+
+5. **`LibPARI.PARI.gpolvar` takes a keyword**, not a positional argument:
+   `gpolvar(; x1 = g)`. Most of LibPARI's generated bindings pass the first
+   argument positionally and the rest as keywords; check the signature before
+   calling one.
+
+6. **`gp_eval` does not honour `setprecision(LibPARI.Gen, …)`.** It goes
+   through the GP interpreter, which reads PARI's process-global
+   `realprecision`, so `setprecision(() -> gp_eval("Pi"), LibPARI.Gen, 512)`
+   returns a 128-bit value. This is documented, intended LibPARI behaviour —
+   its `setprecision` docstring states that the scope "does not reach into
+   the GP interpreter" — and it is worth repeating here because it is easy to
+   trip over when building a test corpus. Call the binding directly,
+   `LibPARI.PARI.mppi()`, when you want the scoped precision to apply. The
+   bridge itself is unaffected: it never asks for a precision other than the
+   value's own.
+
+## API
+
+Both methods live in the extension module, so their docstrings are available
+once `LibPARI` is loaded:
+
+```julia
+using Giac, LibPARI
+
+?to_giac          # includes the method for LibPARI.Gen
+?LibPARI.pari     # includes the method for GiacExpr
+```

--- a/docs/src/llms-full.txt
+++ b/docs/src/llms-full.txt
@@ -5272,6 +5272,266 @@ string(rebuilt) == string(e)   # true
 
 ---
 
+## Section: LibPARI.jl
+<!-- Source: extensions/libpari.md -->
+
+# LibPARI.jl Integration
+
+Giac.jl can exchange values with [LibPARI.jl](https://github.com/s-celles/LibPARI.jl),
+a Julia wrapper for the [PARI/GP](https://pari.math.u-bordeaux.fr/) computer
+algebra system. The bridge is an optional package extension: it becomes
+available as soon as both packages are loaded, and costs nothing otherwise.
+
+```julia
+using Giac, LibPARI
+
+to_giac(gp_eval("(w+x)^2"))     # PARI  -> Giac
+pari(giac_eval("x^2+1"))        # Giac  -> PARI
+```
+
+The bridge lives here, in Giac.jl, rather than in LibPARI.jl. Hosting a bridge
+means paying its CI cost, and `PARI_jll` (19 MB, ~13 Julia dependencies) is far
+cheaper for Giac.jl to pull than `GIAC_jll` (73 MB, ~56 dependencies) would be
+for LibPARI.jl.
+
+## Installation
+
+```julia
+using Pkg
+Pkg.add("Giac")
+Pkg.add("LibPARI")   # 0.17 or later
+```
+
+`LibPARI` is a weak dependency of Giac.jl, so nothing is installed until you
+ask for it. The extension loads automatically when both packages are in scope.
+
+## The two entry points
+
+There is exactly one function per direction, following the convention
+LibPARI's own Symbolics.jl bridge established.
+
+| Direction | Call | Owner of the name |
+|---|---|---|
+| PARI → Giac | `to_giac(g::LibPARI.Gen)` | Giac.jl |
+| Giac → PARI | `LibPARI.pari(e::GiacExpr)` | LibPARI.jl |
+
+The inward direction adds a method to LibPARI's own entry point rather than
+introducing a second name such as `to_pari`. That is not type piracy: LibPARI
+owns `pari`, Giac owns `GiacExpr`. One entry point, one contract.
+
+## The contract
+
+**The bridge is value-preserving and name-preserving. It is not
+representation-preserving.**
+
+A PARI polynomial carries a variable *number* whose *priority* is
+process-global. `varhigher` and `varlower` change that ordering for the whole
+process, so `(w+x)^2` prints as `x^2+2*w*x+w^2` or as `w^2+2*x*w+x^2`
+depending on which ordering is in force. Giac orders by its own rules. The
+variable *name* survives both crossings; the ordering does not.
+
+Consequently:
+
+* Compare round trips **by value**: `pari(to_giac(g)) == g`. On a `Gen`, `==`
+  is PARI's `gequal`.
+* **Never** compare by text: `string(x) == string(y)` is an assertion that
+  will be red or flaky, and the test suite contains no such comparison.
+
+```julia
+using Giac, LibPARI
+
+g = gp_eval("(w+x)^2")
+pari(to_giac(g)) == g        # true — this is the assertion to make
+string(pari(to_giac(g))) == string(g)   # do not rely on this
+```
+
+## Mapping table
+
+Both systems expose a runtime type tag — `LibPARI.gentype(g)` returns a
+`LibPARI.PariType`, `Giac.giac_type(e)` returns a `Giac.GenTypes.T`. The
+table below drives the implementation.
+
+### PARI → Giac (`to_giac`)
+
+| PARI tag | Giac tag | Route | Notes |
+|---|---|---|---|
+| `T_INT` | `INT` / `ZINT` | via `BigInt` | Giac picks the width |
+| `T_FRAC` | `FRAC` | via `Rational{BigInt}` | |
+| `T_REAL` | `REAL` / `DOUBLE` | via `BigFloat` | Giac picks the width by how much precision the value needs |
+| `T_COMPLEX` | `CPLX` | recurse on `real`/`imag` | |
+| `T_POL` | `SYMB` / `IDNT` / scalar | Horner over `gpolvar` | a degree-0 `t_POL` collapses to its constant, which is what PARI's own `==` compares it to |
+| `T_VEC` | `VECT` | elementwise | |
+| `T_COL` | `VECT` | elementwise | **widens** — see limitations |
+| `T_VECSMALL` | `VECT` | elementwise | **widens** |
+| `T_LIST` | `VECT` | elementwise | **widens** |
+| `T_MAT` | `VECT` of `VECT`, row-major | elementwise | `size(g)` reports Julia's `(rows, columns)`; PARI stores columns |
+| anything else | — | **refused, tag named** | |
+
+### Giac → PARI (`LibPARI.pari`)
+
+| Giac tag | PARI tag | Route | Notes |
+|---|---|---|---|
+| `INT` | `T_INT` | via `Int64` | |
+| `ZINT` | `T_INT` | via `BigInt` | |
+| `FRAC` | `T_FRAC` / `T_INT` | `numer`/`denom`, recursively | also covers Giac's habit of storing a complex number with rational parts as a `FRAC`, e.g. `(3+2*i)/4` |
+| `DOUBLE` | `T_REAL` | via `Float64` | PARI has no hardware-float tag |
+| `REAL` | `T_REAL` | via `BigFloat` | see [Reals and precision](@ref) |
+| `CPLX` | `T_COMPLEX` | recurse on real/imaginary part | |
+| `IDNT` | `T_POL` | the free symbol of that name | Giac constants such as `pi` are **refused** |
+| `SYMB` | `T_POL` | `symb2poly` + Horner | only when the expression is a polynomial in its free identifiers |
+| `VECT` (flat) | `T_VEC` | elementwise | |
+| `VECT` of equal-length `VECT`s | `T_MAT` | column by column | |
+| anything else | — | **refused, tag named** | |
+
+## What is refused, and why
+
+Every refusal raises an `ArgumentError` that **names the tag** it could not
+translate, so the message is actionable on its own.
+
+```julia
+julia> to_giac(gp_eval("3+O(5^4)"))
+ERROR: ArgumentError: to_giac: no Giac counterpart for the PARI tag T_PADIC;
+the bridge covers T_INT, T_FRAC, T_REAL, T_COMPLEX, T_POL, T_VEC, T_COL,
+T_VECSMALL, T_LIST and T_MAT
+
+julia> pari(giac_eval("sin(x)"))
+ERROR: ArgumentError: pari: no PARI counterpart for the Giac tag SYMB
+(`sin(x)` is not a polynomial in identifiers — Giac reports `sin(x)` as one of
+its variables); the bridge covers INT, ZINT, FRAC, DOUBLE, REAL, CPLX, IDNT,
+SYMB and VECT
+```
+
+| Refused | Direction | Reason |
+|---|---|---|
+| `T_INTMOD` / `MOD` | both | Giac's `MOD` is opaque to the public API: `op`, `left`, `right` and `feuille` all return the `MOD` itself, so the residue and the modulus cannot be recovered and the value could not come back. Giac also normalises to a symmetric representative — `5 % 7` becomes `-2 % 7` — so even the value is not stable. |
+| `T_STR` / `STRNG` | both | LibPARI exposes no accessor for the characters of a `t_STR` in its public API — `string(g)` returns the GP literal, quotes and escapes included, and reading the value back out of it is the text round trip this contract forbids. Giac's side is fine (`to_julia` on a `STRNG` returns the characters), but one working side is not enough for a round trip, and strings carry no mathematical content for a CAS bridge. If LibPARI gains a public accessor, this row can move to the supported table. |
+| `T_RFRAC`, and any Giac `SYMB` that is a rational function | both | PARI represents `1/(x+1)` as a `t_RFRAC`; the bridge covers polynomials only. `1/x` and `x/(x+1)` are detected through Giac's `denom`. |
+| `T_PADIC`, `T_QUAD`, `T_SER`, `T_POLMOD`, `T_CLOSURE`, … | outward | No Giac counterpart. |
+| Giac `SYMB` involving `sin`, `exp`, `sqrt`, … | inward | Not a polynomial. Giac's `lvar` reports each such subexpression as a generalised variable rather than as an identifier, which is exactly the test the bridge applies. |
+| Giac `IDNT` that is a constant (`pi`, `i`, …) | inward | A PARI variable named `pi` is not Giac's π, and inventing one would be wrong. |
+| A ragged or mixed Giac `VECT` | inward | PARI has no ragged container. Only a rectangular nesting maps onto a `t_MAT`. |
+| Giac `POLY`, `FUNC`, `MAP`, … | inward | No PARI counterpart. |
+
+## Reals and precision
+
+Precision is a scope. `setprecision(LibPARI.Gen, bits) do … end` sets
+LibPARI's working precision in bits, and it governs PARI *computations*.
+
+**The bridge does not consult it.** A real crosses carrying the precision of
+the value itself, in both directions — a 512-bit `t_REAL` reaches Giac with
+all 512 bits even while the ambient setting is 64, and comes back a 512-bit
+`t_REAL`.
+
+```julia
+using Giac, LibPARI
+
+wide = setprecision(() -> LibPARI.PARI.mppi(), LibPARI.Gen, 512)
+precision(wide)                                   # 512
+
+setprecision(LibPARI.Gen, 64) do
+    pari(to_giac(wide)) == wide                   # true
+end
+precision(pari(to_giac(wide)))                    # 512
+```
+
+### Why the bridge never routes a value through text
+
+Injecting a PARI real into GP as a decimal string turns a 512-bit real into a
+128-bit one, silently, because PARI prints at the current `realprecision`:
+
+```julia
+p = setprecision(() -> LibPARI.PARI.mppi(), LibPARI.Gen, 512)
+precision(p)                             # 512
+precision(gp_eval(string(p)))            # 128  — no error, no warning
+```
+
+Values therefore cross structurally, or through exact Julia values (`BigInt`,
+`Rational`, `BigFloat`) — never through `string`. `BigFloat(::Gen)` widens the
+working precision to hold the mantissa exactly, and `LibPARI.pari(::BigFloat)`
+rebuilds a `t_REAL` from the mantissa and exponent, so the PARI legs are exact
+by construction.
+
+### The one place text is unavoidable
+
+Reading a Giac `REAL` back out is the exception, and it is worth stating
+plainly. The libgiac wrapper exposes `to_double` — a `Float64`, and therefore
+lossy — and nothing for an MPFR value; reaching past it into an undeclared
+libgiac C symbol is a call this project does not make. Giac's printer does,
+however, emit a `REAL` at that value's *own* precision rather than at a global
+setting, so the decimal it produces is faithful and only the bit width has to
+be recovered.
+
+The bridge recovers that width by search and then **verifies** it: a candidate
+is accepted only when re-encoding it reproduces Giac's own printed form
+character for character. A width that cannot be verified raises rather than
+returning a quietly-rounded value. The behaviour is pinned by tests at 64,
+128, 192, 256, 384, 512 and 1024 bits.
+
+This would become unnecessary if the wrapper gained an MPFR accessor for
+`REAL`; until then it is the bridge's only text-mediated step, and it is
+checked rather than trusted.
+
+## Known limitations
+
+Each of these is pinned by a test, so a change in behaviour shows up in
+Giac.jl's suite rather than in your results.
+
+1. **`T_COL`, `T_VECSMALL` and `T_LIST` widen to `T_VEC`.** Giac has a single
+   vector type, so the container tag cannot survive. The elements do.
+
+   ```julia
+   g = gp_eval("[1,2,3]~")           # a t_COL
+   back = pari(to_giac(g))
+   back == gp_eval("[1,2,3]")        # true  — values preserved
+   LibPARI.gentype(back)             # T_VEC — tag not preserved
+   back == g                         # false
+   ```
+
+   If you need the round trip to be tag-exact, normalise on the PARI side
+   first with `Vec(...)`.
+
+2. **PARI's variable ordering does not cross**, as described under
+   [The contract](@ref). Compare by value.
+
+3. **Float tags are not preserved.** Giac's `DOUBLE` and `REAL` both land on
+   PARI's `t_REAL`; coming back, Giac picks `DOUBLE` or `REAL` according to
+   how much precision the value needs. Values are preserved either way.
+
+4. **A `Gen` is not a `Number`.** It is a `LibPARI.PariObject`. Generic
+   numeric code bounded by `T<:Number` will not accept one, and `Number`
+   methods must not be assumed to apply.
+
+5. **`LibPARI.PARI.gpolvar` takes a keyword**, not a positional argument:
+   `gpolvar(; x1 = g)`. Most of LibPARI's generated bindings pass the first
+   argument positionally and the rest as keywords; check the signature before
+   calling one.
+
+6. **`gp_eval` does not honour `setprecision(LibPARI.Gen, …)`.** It goes
+   through the GP interpreter, which reads PARI's process-global
+   `realprecision`, so `setprecision(() -> gp_eval("Pi"), LibPARI.Gen, 512)`
+   returns a 128-bit value. This is documented, intended LibPARI behaviour —
+   its `setprecision` docstring states that the scope "does not reach into
+   the GP interpreter" — and it is worth repeating here because it is easy to
+   trip over when building a test corpus. Call the binding directly,
+   `LibPARI.PARI.mppi()`, when you want the scoped precision to apply. The
+   bridge itself is unaffected: it never asks for a precision other than the
+   value's own.
+
+## API
+
+Both methods live in the extension module, so their docstrings are available
+once `LibPARI` is loaded:
+
+```julia
+using Giac, LibPARI
+
+?to_giac          # includes the method for LibPARI.Gen
+?LibPARI.pari     # includes the method for GiacExpr
+```
+
+
+---
+
 ## Section: Overview
 <!-- Source: developer/index.md -->
 

--- a/docs/src/llms.txt
+++ b/docs/src/llms.txt
@@ -30,6 +30,7 @@
 - [MathJSON.jl](extensions/mathjson.html)
 - [MCP Server](extensions/mcp.html)
 - [TermInterface.jl](extensions/terminterface.html)
+- [LibPARI.jl](extensions/libpari.html)
 - [Overview](developer/index.html)
 - [Package Architecture](developer/architecture.html)
 - [Performance Tiers](developer/tier-system.html)

--- a/ext/GiacLibPARIExt.jl
+++ b/ext/GiacLibPARIExt.jl
@@ -1,0 +1,394 @@
+# ---------------------------------------------------------------------------
+# GiacLibPARIExt — the LibPARI.jl bridge.
+#
+# Loaded only when `LibPARI` is loaded alongside `Giac`. Giac.jl hosts this
+# bridge rather than LibPARI.jl because the CI cost lands on the host, and
+# `PARI_jll` (19 MB, ~13 deps) is far cheaper for Giac.jl to pull than
+# `GIAC_jll` (73 MB, ~56 deps) would be for LibPARI.jl.
+#
+# CONTRACT — value-preserving and name-preserving; NOT representation-
+# preserving.
+#
+#   * A PARI polynomial carries a variable *number* with a process-global
+#     *priority*. `varhigher`/`varlower` change it for the whole process, so
+#     `(w+x)^2` prints as `x^2+2*w*x+w^2` or `w^2+2*x*w+x^2` depending on the
+#     ordering in force. Giac has its own ordering rules. The variable *name*
+#     survives both crossings; the ordering does not.
+#   * Compare round trips by value — `pari(to_giac(g)) == g`, where `==` on a
+#     `Gen` is PARI's `gequal`. Never compare by `string`: that assertion is
+#     red or flaky by construction.
+#
+# Two entry points, matching the convention LibPARI's own Symbolics bridge
+# established:
+#
+#   outward (PARI → Giac)   `Giac.to_giac(g::LibPARI.Gen)`
+#   inward  (Giac → PARI)   `LibPARI.pari(e::GiacExpr)`
+#
+# Adding a method to `LibPARI.pari` is not piracy: LibPARI owns `pari`, Giac
+# owns `GiacExpr`. There is deliberately no second inward name.
+#
+# See docs/src/extensions/libpari.md for the full mapping table, the refusal
+# list and the measured limitations.
+# ---------------------------------------------------------------------------
+
+module GiacLibPARIExt
+
+using Giac
+using Giac.GenTypes
+using LibPARI
+
+const PT = LibPARI.PariType
+const P = LibPARI.PARI
+
+# Tags this bridge translates, quoted in every refusal message so the caller
+# learns the supported set from the error itself.
+const OUTWARD_SUPPORTED =
+    "T_INT, T_FRAC, T_REAL, T_COMPLEX, T_POL, T_VEC, T_COL, T_VECSMALL, " *
+    "T_LIST and T_MAT"
+const INWARD_SUPPORTED = "INT, ZINT, FRAC, DOUBLE, REAL, CPLX, IDNT, SYMB and VECT"
+
+# ===========================================================================
+# Reals
+#
+# Neither direction may go through a printed decimal chosen by a printer: a
+# PARI `t_REAL` prints at the ambient `realprecision`, so injecting one into
+# GP as text turns a 512-bit real into 128 bits with no diagnostic.
+#
+# PARI → Giac is structural on both legs. `BigFloat(::Gen)` widens the
+# working precision to hold the mantissa exactly, and `LibPARI.pari` builds a
+# `t_REAL` from a `BigFloat`'s mantissa and exponent.
+#
+# Giac → Julia is the one place the bridge has no structural route: the
+# libgiac wrapper exposes `to_double` (a `Float64`, and therefore lossy) and
+# nothing for an MPFR value, and reaching past it into an undeclared libgiac
+# C symbol is exactly the class of call this project does not make. Giac's
+# printer does, however, emit a REAL at that value's *own* precision rather
+# than at a global setting — so the decimal is faithful, and only the bit
+# width has to be recovered. `_giac_real_to_bigfloat` recovers it by search
+# and *verifies* the result: the candidate is accepted only when re-encoding
+# it reproduces Giac's own printed form character for character. A width that
+# cannot be verified raises rather than returning a quietly-rounded value.
+# ===========================================================================
+
+# Significant decimal digits in Giac's rendering of a REAL.
+function _significant_digits(s::AbstractString)
+    mantissa = first(split(s, r"[eE]"))
+    return count(isdigit, mantissa)
+end
+
+"""
+Recover the exact `BigFloat` behind a Giac `REAL`.
+
+MPFR renders a `p`-bit value with `ceil(p * log10(2)) + 1` significant
+digits, which pins `p` only to within a few bits; the loop closes that gap by
+re-encoding each candidate and keeping the width whose rendering matches.
+"""
+function _giac_real_to_bigfloat(g::GiacExpr)
+    s = string(g)
+    tryparse(BigFloat, s) === nothing &&
+        throw(ArgumentError("pari: cannot read the Giac REAL `$s` as a BigFloat"))
+    d = _significant_digits(s)
+    lo = max(2, floor(Int, (d - 2) / log10(2)) - 8)
+    hi = ceil(Int, (d - 1) / log10(2)) + 8
+    for p = lo:hi
+        b = setprecision(() -> parse(BigFloat, s), BigFloat, p)
+        string(convert(GiacExpr, b)) == s && return b
+    end
+    throw(
+        ArgumentError(
+            "pari: could not determine the working precision of the Giac REAL " *
+            "`$s`; no width in $lo:$hi reproduces it. Please report this with " *
+            "the value, at https://github.com/s-celles/Giac.jl/issues",
+        ),
+    )
+end
+
+# ===========================================================================
+# PARI → Giac
+# ===========================================================================
+
+# The name of a polynomial's main variable, as PARI reports it. `gpolvar`
+# returns the free symbol itself, whose text is the name; note the keyword —
+# it takes `x1 = g`, not a positional argument.
+_mainvar_name(g::LibPARI.Gen) = string(P.gpolvar(; x1 = g))
+
+_refuse_outward(t) = throw(
+    ArgumentError(
+        "to_giac: no Giac counterpart for the PARI tag $t; the bridge covers " *
+        OUTWARD_SUPPORTED,
+    ),
+)
+
+"""
+    to_giac(g::LibPARI.Gen) -> GiacExpr
+
+Convert a PARI/GP value to a Giac expression.
+
+The conversion is value-preserving and name-preserving, but not
+representation-preserving: PARI's variable priority — a process-global
+ordering — does not cross, and Giac reorders by its own rules. Compare round
+trips with `==`, never with `string`.
+
+Supported tags: `T_INT`, `T_FRAC`, `T_REAL`, `T_COMPLEX`, `T_POL`, `T_VEC`,
+`T_COL`, `T_VECSMALL`, `T_LIST` and `T_MAT`. Any other tag raises an
+`ArgumentError` naming it. `T_COL`, `T_VECSMALL` and `T_LIST` widen to a Giac
+`VECT` and therefore return as a `T_VEC`.
+
+# Examples
+
+```julia
+using Giac, LibPARI
+
+to_giac(pari(3 // 4))                # 3/4
+to_giac(gp_eval("(w+x)^2"))          # a Giac SYMB in w and x
+pari(to_giac(gp_eval("x^2+1")))      # back again, equal by `==`
+```
+
+See also [`LibPARI.pari`](@ref) for the inward direction.
+"""
+function Giac.to_giac(g::LibPARI.Gen)::GiacExpr
+    t = LibPARI.gentype(g)
+
+    if t === PT.T_INT
+        return convert(GiacExpr, BigInt(g))
+    elseif t === PT.T_FRAC
+        return convert(GiacExpr, Rational{BigInt}(g))
+    elseif t === PT.T_REAL
+        # `BigFloat(::Gen)` widens as needed, so this leg never rounds.
+        return convert(GiacExpr, BigFloat(g))
+    elseif t === PT.T_COMPLEX
+        return Giac.to_giac(real(g)) + Giac.to_giac(imag(g)) * giac_eval("i")
+    elseif t === PT.T_POL
+        return _pol_to_giac(g)
+    elseif t === PT.T_VEC || t === PT.T_COL || t === PT.T_VECSMALL || t === PT.T_LIST
+        return _giac_vect([Giac.to_giac(x) for x in g])
+    elseif t === PT.T_MAT
+        nrows, ncols = size(g)
+        return _giac_vect([
+            _giac_vect([Giac.to_giac(g[i, j]) for j = 1:ncols]) for i = 1:nrows
+        ])
+    end
+
+    return _refuse_outward(t)
+end
+
+# Horner over the main variable; each coefficient converts recursively, so a
+# multivariate polynomial nests correctly. A `t_POL` of degree 0 collapses to
+# its constant, which is what PARI's own `==` compares it to.
+function _pol_to_giac(g::LibPARI.Gen)::GiacExpr
+    iszero(g) && return convert(GiacExpr, 0)
+    v = giac_eval(_mainvar_name(g))
+    d = LibPARI.degree(g)
+    acc = Giac.to_giac(LibPARI.coeff(g, d))
+    for k = (d-1):-1:0
+        acc = acc * v + Giac.to_giac(LibPARI.coeff(g, k))
+    end
+    return acc
+end
+
+# A Giac VECT from Julia-side elements, built through Giac's own vector
+# constructor rather than by printing the elements into a bracket list.
+#
+# `makevector` is not a faithful wrapper at length one: handed a single
+# vector it returns that vector instead of a vector containing it, which
+# would silently turn a one-row PARI `t_MAT` into a flat `t_VEC` on the way
+# back. Length one therefore goes through `mid`, which does wrap.
+function _giac_vect(xs::Vector{GiacExpr})::GiacExpr
+    isempty(xs) && return giac_eval("[]")
+    length(xs) == 1 &&
+        return Giac.Commands.mid(Giac.Commands.makevector(xs[1], xs[1]), 0, 1)
+    return Giac.Commands.makevector(xs...)
+end
+
+# ===========================================================================
+# Giac → PARI
+# ===========================================================================
+
+# PARI's imaginary unit, fetched by name through GP. A *name* through text is
+# safe — it is the value round trip that loses precision.
+_pari_i() = LibPARI.gp_eval("I")
+
+_refuse_inward(t, why = "") = throw(
+    ArgumentError(
+        "pari: no PARI counterpart for the Giac tag $t" *
+        (isempty(why) ? "" : " ($why)") *
+        "; the bridge covers " *
+        INWARD_SUPPORTED,
+    ),
+)
+
+"""
+    LibPARI.pari(e::Giac.GiacExpr) -> LibPARI.Gen
+
+Convert a Giac expression to a PARI/GP value.
+
+This is a method on LibPARI's own single inward entry point, not a second
+name: `pari` is LibPARI's, `GiacExpr` is Giac's, so the method is well-owned
+by neither package alone and lives in this bridge.
+
+Supported tags: `INT`, `ZINT`, `FRAC`, `DOUBLE`, `REAL`, `CPLX`, `IDNT`,
+`SYMB` (when the expression is a polynomial in its free identifiers) and
+`VECT`. Any other tag — `MOD`, `STRNG`, `POLY`, `FUNC`, … — raises an
+`ArgumentError` naming it.
+
+# Examples
+
+```julia
+using Giac, LibPARI
+
+pari(giac_eval("3/4"))               # 3/4, a t_FRAC
+pari(giac_eval("x^2+1"))             # x^2 + 1, a t_POL
+to_giac(pari(giac_eval("[1,2,3]")))  # round trip through a t_VEC
+```
+
+See also [`Giac.to_giac`](@ref) for the outward direction.
+"""
+function LibPARI.pari(e::GiacExpr)::LibPARI.Gen
+    t = Giac.giac_type(e)
+
+    if t == INT
+        return LibPARI.pari(to_julia(e))
+    elseif t == ZINT
+        return LibPARI.pari(BigInt(to_julia(e)))
+    elseif t == DOUBLE
+        return LibPARI.pari(Float64(to_julia(e)))
+    elseif t == REAL
+        return LibPARI.pari(_giac_real_to_bigfloat(e))
+    elseif t == FRAC
+        # `numer`/`denom` recurse, which also covers Giac's habit of storing a
+        # complex number with rational parts as a FRAC — `(3+2*i)/4`, whose
+        # `real_part` is the whole fraction rather than `3/4`.
+        return LibPARI.pari(Giac.numer(e)) / LibPARI.pari(Giac.denom(e))
+    elseif t == CPLX
+        return LibPARI.pari(Giac.real_part(e)) + LibPARI.pari(Giac.imag_part(e)) * _pari_i()
+    elseif t == IDNT
+        # `pi`, `e` and friends are IDNTs too, and a PARI variable named `pi`
+        # is not Giac's π. Refuse rather than invent one.
+        Giac.is_constant(e) && _refuse_inward(
+            t,
+            "`$e` is a Giac constant, not a free variable; PARI has no " *
+            "same-named counterpart and a variable of that name would not " *
+            "mean the same thing",
+        )
+        return LibPARI.gp_eval(string(e))
+    elseif t == SYMB
+        return _symb_to_pari(e)
+    elseif t == VECT
+        return _vect_to_pari(e)
+    end
+
+    return _refuse_inward(t)
+end
+
+# --- polynomials -----------------------------------------------------------
+
+# A Giac SYMB reaches PARI only when it is a polynomial in its free
+# identifiers. `lvar` reports the *generalised* variables of an expression:
+# `sqrt(2)`, `sin(x)` and `exp(x)` each come back as a variable of their own
+# rather than as an identifier, which is precisely the test for "polynomial
+# in identifiers". `1/x` and `x/(x+1)` pass that test but are rational
+# functions, so the denominator is checked separately.
+function _symb_to_pari(e::GiacExpr)::LibPARI.Gen
+    vars = _elements(Giac.Commands.lvar(e))
+
+    for v in vars
+        Giac.giac_type(v) == IDNT || _refuse_inward(
+            SYMB,
+            "`$e` is not a polynomial in identifiers — Giac reports `$v` as one " *
+            "of its variables",
+        )
+        Giac.is_constant(v) && _refuse_inward(
+            SYMB,
+            "`$e` involves the Giac constant `$v`, which has no PARI counterpart",
+        )
+    end
+
+    # `Giac.denom` is restricted to fractions and integers; the Giac command
+    # of the same name answers for any expression, and reports `x+1` for
+    # `x/(x+1)` and `1` for `x^2+1`.
+    den = Giac.Commands.denom(e)
+    isempty(_elements(Giac.Commands.lvar(den))) || _refuse_inward(
+        SYMB,
+        "`$e` is a rational function with denominator `$den`, not a polynomial; " *
+        "PARI would represent it as a t_RFRAC, which this bridge does not cover",
+    )
+
+    isempty(vars) && return LibPARI.pari(to_julia(e))
+
+    v = first(vars)
+    coeffs = _elements(Giac.Commands.symb2poly(e, v))
+    isempty(coeffs) && return LibPARI.pari(0)
+
+    # `symb2poly` returns coefficients in descending degree.
+    pv = LibPARI.gp_eval(string(v))
+    acc = LibPARI.pari(first(coeffs))
+    for c in coeffs[2:end]
+        acc = acc * pv + LibPARI.pari(c)
+    end
+    return acc
+end
+
+# --- containers ------------------------------------------------------------
+
+_elements(v::GiacExpr)::Vector{GiacExpr} =
+    Giac.giac_type(v) == VECT ? GiacExpr[v[i] for i = 1:length(v)] : GiacExpr[]
+
+# Build a `t_VEC` from its elements.
+#
+# `Vec(x)` is *not* a one-element wrapper: on a `t_POL` it returns the
+# coefficient vector and on a container it flattens, so `Vec` cannot start
+# this fold. `concat` is the right primitive — it splices vectors and
+# matrices but treats a `t_POL` as a scalar — and `vecextract` supplies the
+# one-element case that `concat` alone cannot express.
+#
+# Callers must therefore pass scalars or polynomials only; `_vect_to_pari`
+# routes a nested Giac vector to `t_MAT` and refuses every other nesting.
+function _pari_vec(xs::Vector{LibPARI.Gen})::LibPARI.Gen
+    isempty(xs) && return LibPARI.gp_eval("[]")
+    length(xs) == 1 &&
+        return P.extract0(P.gconcat(first(xs); x2 = first(xs)), LibPARI.pari(1); x3 = nothing)
+    return foldl(
+        (a, b) -> P.gconcat(a; x2 = b),
+        xs[3:end];
+        init = P.gconcat(xs[1]; x2 = xs[2]),
+    )
+end
+
+function _vect_to_pari(e::GiacExpr)::LibPARI.Gen
+    rows = _elements(e)
+    isempty(rows) && return LibPARI.gp_eval("[]")
+
+    if all(r -> Giac.giac_type(r) == VECT, rows)
+        widths = [length(r) for r in rows]
+        allequal(widths) || throw(
+            ArgumentError(
+                "pari: the Giac VECT `$e` nests vectors of differing lengths " *
+                "$(widths); PARI has no ragged container, and this bridge maps " *
+                "only a rectangular nesting onto a t_MAT",
+            ),
+        )
+        first(widths) == 0 && return LibPARI.gp_eval("[]")
+
+        ncols = first(widths)
+        cols = LibPARI.Gen[]
+        for j = 1:ncols
+            col = P.gtocol0(
+                _pari_vec(LibPARI.Gen[LibPARI.pari(r[j]) for r in rows]);
+                x2 = 0,
+            )
+            push!(cols, P.gtomat(; x1 = col))
+        end
+        return foldl((a, b) -> P.gconcat(a; x2 = b), cols[2:end]; init = first(cols))
+    end
+
+    any(r -> Giac.giac_type(r) == VECT, rows) && throw(
+        ArgumentError(
+            "pari: the Giac VECT `$e` mixes vector and scalar elements; PARI " *
+            "has no counterpart for that shape",
+        ),
+    )
+
+    return _pari_vec(LibPARI.Gen[LibPARI.pari(r) for r in rows])
+end
+
+end # module GiacLibPARIExt

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -171,6 +171,15 @@ using LinearAlgebra
     include("test_mcp_ext.jl")
 
     # ============================================================================
+    # LibPARI Extension Tests (071-libpari-bridge)
+    # Verifies to_giac(::LibPARI.Gen) / LibPARI.pari(::GiacExpr) round trips,
+    # the refusal list and the documented limitations.
+    # A dedicated CI job also runs this file standalone, against a project
+    # holding only Giac and LibPARI.
+    # ============================================================================
+    include("test_libpari_ext.jl")
+
+    # ============================================================================
     # Doctests
     # Runs jldoctest blocks in Giac docstrings via Documenter.doctest
     # ============================================================================

--- a/test/test_libpari_ext.jl
+++ b/test/test_libpari_ext.jl
@@ -1,0 +1,414 @@
+# ============================================================================
+# LibPARI Extension Tests (071-libpari-bridge)
+#
+# Exercises `GiacLibPARIExt`: `to_giac(::LibPARI.Gen)` outward and
+# `LibPARI.pari(::GiacExpr)` inward.
+#
+# Two rules govern every assertion here:
+#
+#   * Round trips are compared **by value** — `pari(to_giac(g)) == g`, where
+#     `==` on a `Gen` is PARI's `gequal`. There is deliberately no
+#     `string(x) == string(y)` anywhere in this file: PARI's variable
+#     priority is process-global and Giac orders by its own rules, so a
+#     textual comparison is red or flaky by construction.
+#   * Every refusal is asserted to **name the tag** it could not translate.
+#
+# The file is self-contained so the dedicated CI job can run it against a
+# project holding nothing but Giac and LibPARI — which is what proves the
+# bridge does not quietly depend on another extension having loaded first.
+# ============================================================================
+
+using Test
+using Giac
+using Giac.GenTypes
+using LibPARI
+
+const PT = LibPARI.PariType
+const GP = LibPARI.PARI
+
+@testset "LibPARI Extension" begin
+
+    @testset "Extension loads" begin
+        @test !isnothing(Base.get_extension(Giac, :GiacLibPARIExt))
+        @test hasmethod(Giac.to_giac, Tuple{LibPARI.Gen})
+        @test hasmethod(LibPARI.pari, Tuple{GiacExpr})
+    end
+
+    # ------------------------------------------------------------------
+    # Round trips by value, PARI first.
+    # ------------------------------------------------------------------
+    @testset "Round trip PARI -> Giac -> PARI" begin
+        @testset "integers" begin
+            for g in (
+                LibPARI.pari(0),
+                LibPARI.pari(42),
+                LibPARI.pari(-7),
+                LibPARI.pari(typemax(Int)),
+                LibPARI.pari(typemin(Int)),
+                LibPARI.pari(big(2)^200 + 1),
+                LibPARI.pari(-big(3)^150),
+            )
+                @test LibPARI.pari(to_giac(g)) == g
+            end
+        end
+
+        @testset "rationals" begin
+            for g in (
+                LibPARI.pari(3 // 4),
+                LibPARI.pari(-22 // 7),
+                LibPARI.pari(big(2)^100 // 7),
+                LibPARI.pari(1 // big(3)^80),
+            )
+                @test LibPARI.pari(to_giac(g)) == g
+            end
+        end
+
+        @testset "complex" begin
+            for src in ("3+4*I", "-1+I", "3/4+5/6*I", "(2^100)+I")
+                g = LibPARI.gp_eval(src)
+                @test LibPARI.gentype(g) === PT.T_COMPLEX
+                @test LibPARI.pari(to_giac(g)) == g
+            end
+        end
+
+        @testset "polynomials" begin
+            for src in (
+                "x^2+1",
+                "3*x^5-2*x^3+x-7",
+                "Pol(5)",
+                "0*x",
+                "x",
+                "(w+x)^2",
+                "w^3*x + 2*w - x^2 + 5",
+                "x^2/3 + 1/7",
+                "y^7-1",
+                "(a+b+c)^2",
+            )
+                g = LibPARI.gp_eval(src)
+                @test LibPARI.pari(to_giac(g)) == g
+            end
+        end
+
+        @testset "vectors" begin
+            for src in ("[]", "[1,2,3]", "[7]", "[1, 3/4, x^2+1]", "[-1,0,1]")
+                g = LibPARI.gp_eval(src)
+                @test LibPARI.pari(to_giac(g)) == g
+            end
+        end
+
+        @testset "matrices" begin
+            for src in ("[1,2;3,4]", "[1,2;3,4;5,6]", "Mat(7)", "[x,1;0,x^2]", "[1,2,3]")
+                g = LibPARI.gp_eval(src)
+                @test LibPARI.pari(to_giac(g)) == g
+            end
+            # A one-row t_MAT must not collapse into a t_VEC on the way back:
+            # Giac's own `makevector` unwraps a lone vector argument, and the
+            # bridge compensates.
+            m = LibPARI.gp_eval("Mat(7)")
+            @test LibPARI.gentype(LibPARI.pari(to_giac(m))) === PT.T_MAT
+        end
+    end
+
+    # ------------------------------------------------------------------
+    # Round trips by value, Giac first.
+    # ------------------------------------------------------------------
+    @testset "Round trip Giac -> PARI -> Giac" begin
+        for src in (
+            "42",
+            "-7",
+            "2^200",
+            "3/4",
+            "2^100/7",
+            "1.5",
+            "3+4*i",
+            "x",
+            "x^2+1",
+            "2*x*y+1",
+            "(w+x)^2",
+            "[1,2,3]",
+            "[[1,2],[3,4]]",
+        )
+            e = giac_eval(src)
+            p = LibPARI.pari(e)
+            # `to_giac` back, then out again: the value must be a fixed point
+            # of the crossing even though neither side's printed form is.
+            @test LibPARI.pari(to_giac(p)) == p
+        end
+    end
+
+    # ------------------------------------------------------------------
+    # Reals. Precision is a scope; the bridge carries the *value's* own
+    # precision, never the ambient setting.
+    # ------------------------------------------------------------------
+    @testset "Reals" begin
+        @testset "round trip at several precisions" begin
+            for bits in (64, 128, 192, 256, 384, 512, 1024)
+                p = setprecision(() -> GP.mppi(), LibPARI.Gen, bits)
+                @test precision(p) == bits
+                @test LibPARI.pari(to_giac(p)) == p
+            end
+        end
+
+        @testset "assorted magnitudes" begin
+            for src in ("sqrt(2)", "1/3.", "-Pi", "Pi*2^-300", "Pi*2^300", "exp(1)")
+                p = LibPARI.gp_eval(src)
+                @test LibPARI.gentype(p) === PT.T_REAL
+                @test LibPARI.pari(to_giac(p)) == p
+            end
+        end
+
+        @testset "the value's precision, not the ambient one" begin
+            # A 512-bit real crosses unchanged even while LibPARI's working
+            # precision is set to 64 bits, and vice versa.
+            wide = setprecision(() -> GP.mppi(), LibPARI.Gen, 512)
+            narrow = setprecision(() -> GP.mppi(), LibPARI.Gen, 64)
+            setprecision(LibPARI.Gen, 64) do
+                @test LibPARI.pari(to_giac(wide)) == wide
+            end
+            setprecision(LibPARI.Gen, 512) do
+                @test LibPARI.pari(to_giac(narrow)) == narrow
+            end
+            # The ambient `BigFloat` precision is likewise not consulted.
+            setprecision(BigFloat, 53) do
+                @test LibPARI.pari(to_giac(wide)) == wide
+            end
+        end
+
+        @testset "a wide real survives inside a container" begin
+            # The length-one container paths are the ones most likely to reach
+            # for a textual detour, on either side. A 512-bit real inside a
+            # one-element vector and a 1x1 matrix pins that they do not.
+            wide = setprecision(() -> GP.mppi(), LibPARI.Gen, 512)
+            onevec = GP.extract0(GP.gconcat(wide; x2 = wide), LibPARI.pari(1); x3 = nothing)
+            onemat = GP.gtomat(; x1 = GP.gtocol0(onevec; x2 = 0))
+            for g in (onevec, onemat, GP.gconcat(wide; x2 = LibPARI.pari(1)))
+                @test LibPARI.pari(to_giac(g)) == g
+            end
+            @test precision(LibPARI.pari(to_giac(onevec))[1]) == 512
+        end
+
+        @testset "float tags are not preserved, only values" begin
+            # Giac's DOUBLE is a Float64; PARI has no distinct hardware-float
+            # tag, so it lands on t_REAL.
+            p = LibPARI.pari(giac_eval("1.5"))
+            @test LibPARI.gentype(p) === PT.T_REAL
+            @test p == LibPARI.pari(1.5)
+
+            # Coming the other way, Giac picks DOUBLE or REAL by how much
+            # precision the value actually needs — a narrow t_REAL lands on
+            # DOUBLE, a wide one on REAL. Either way the value survives.
+            narrow = to_giac(LibPARI.pari(1.5))
+            wide = to_giac(setprecision(() -> GP.mppi(), LibPARI.Gen, 512))
+            @test Giac.giac_type(narrow) in (DOUBLE, REAL)
+            @test Giac.giac_type(wide) == REAL
+            @test LibPARI.pari(narrow) == LibPARI.pari(1.5)
+        end
+    end
+
+    # ------------------------------------------------------------------
+    # Names survive; representation does not.
+    # ------------------------------------------------------------------
+    @testset "Variable names survive" begin
+        @testset "outward" begin
+            for (src, want) in (
+                ("x^2+1", ["x"]),
+                ("(w+x)^2", ["w", "x"]),
+                ("y^3-y", ["y"]),
+                ("a*b*c", ["a", "b", "c"]),
+            )
+                g = to_giac(LibPARI.gp_eval(src))
+                got = sort([string(v) for v in Giac.Commands.lvar(g)])
+                @test got == sort(want)
+            end
+        end
+
+        @testset "inward" begin
+            # `gpolvar` takes a keyword, not a positional argument.
+            for (src, want) in (("x^2+1", "x"), ("y^3-y", "y"))
+                back = LibPARI.pari(to_giac(LibPARI.gp_eval(src)))
+                @test string(GP.gpolvar(; x1 = back)) == want
+            end
+        end
+
+        @testset "a Giac-side name reaches PARI" begin
+            @giac_var zz
+            p = LibPARI.pari(zz^2 + 1)
+            @test LibPARI.gentype(p) === PT.T_POL
+            @test string(GP.gpolvar(; x1 = p)) == "zz"
+        end
+    end
+
+    # ------------------------------------------------------------------
+    # Refusals — each must name the tag it could not translate.
+    # ------------------------------------------------------------------
+    @testset "Refusals name the tag" begin
+        @testset "outward" begin
+            for (tag, src) in (
+                ("T_INTMOD", "Mod(3,7)"),
+                ("T_PADIC", "3+O(5^4)"),
+                ("T_QUAD", "quadgen(5)"),
+                ("T_RFRAC", "1/(x+1)"),
+                ("T_SER", "1+x+O(x^3)"),
+                ("T_POLMOD", "Mod(x,x^2+1)"),
+                ("T_STR", "\"hi\""),
+            )
+                g = LibPARI.gp_eval(src)
+                err = try
+                    to_giac(g)
+                    nothing
+                catch e
+                    e
+                end
+                @test err isa ArgumentError
+                msg = sprint(showerror, err)
+                @test occursin(tag, msg)
+                @test occursin("to_giac", msg)
+            end
+        end
+
+        @testset "inward" begin
+            for (tag, src, hint) in (
+                ("MOD", "3 % 7", ""),
+                ("STRNG", "\"hi\"", ""),
+                ("SYMB", "sin(x)", "sin(x)"),
+                ("SYMB", "sqrt(2)", "sqrt(2)"),
+                ("SYMB", "exp(x)+x", "exp(x)"),
+                ("SYMB", "1/x", "rational function"),
+                ("SYMB", "x/(x+1)", "rational function"),
+                ("IDNT", "pi", "constant"),
+            )
+                e = giac_eval(src)
+                err = try
+                    LibPARI.pari(e)
+                    nothing
+                catch ex
+                    ex
+                end
+                @test err isa ArgumentError
+                msg = sprint(showerror, err)
+                @test occursin(tag, msg)
+                @test occursin("pari", msg)
+                isempty(hint) || @test occursin(hint, msg)
+            end
+        end
+
+        @testset "a ragged Giac vector is refused, with its shape named" begin
+            e = giac_eval("[[1,2],[3]]")
+            err = try
+                LibPARI.pari(e)
+                nothing
+            catch ex
+                ex
+            end
+            @test err isa ArgumentError
+            @test occursin("ragged", sprint(showerror, err))
+        end
+
+        @testset "a Giac vector mixing scalars and vectors is refused" begin
+            e = giac_eval("[1,[2,3]]")
+            err = try
+                LibPARI.pari(e)
+                nothing
+            catch ex
+                ex
+            end
+            @test err isa ArgumentError
+            @test occursin("mixes vector and scalar", sprint(showerror, err))
+        end
+    end
+
+    # ------------------------------------------------------------------
+    # Documented limitations. Each is pinned by a test so that a change in
+    # behaviour shows up here rather than in a user's results.
+    # ------------------------------------------------------------------
+    @testset "Documented limitations" begin
+        @testset "T_COL, T_VECSMALL and T_LIST widen to T_VEC" begin
+            for src in ("[1,2,3]~", "Vecsmall([1,2,3])", "List([1,2,3])")
+                g = LibPARI.gp_eval(src)
+                back = LibPARI.pari(to_giac(g))
+                # The elements survive …
+                @test back == LibPARI.gp_eval("[1,2,3]")
+                # … the container tag does not. Giac has one vector type.
+                @test LibPARI.gentype(back) === PT.T_VEC
+                @test LibPARI.gentype(back) !== LibPARI.gentype(g)
+                @test !(back == g)
+            end
+        end
+
+        @testset "PARI's variable ordering does not cross" begin
+            # `(w+x)^2` is equal by value across the bridge, but the printed
+            # form depends on a process-global priority on the PARI side and
+            # on Giac's own rules on the other. This is the assertion this
+            # suite makes; `string` equality is never asserted anywhere.
+            g = LibPARI.gp_eval("(w+x)^2")
+            @test LibPARI.pari(to_giac(g)) == g
+        end
+
+        @testset "a Gen is not a Number" begin
+            # Generic numeric code bounded by `T<:Number` will not accept a
+            # `Gen`; callers must not assume `Number` methods apply.
+            @test !(LibPARI.Gen <: Number)
+            @test LibPARI.pari(42) isa LibPARI.PariObject
+        end
+    end
+
+    # ------------------------------------------------------------------
+    # Traps, pinned so nobody rediscovers them.
+    # ------------------------------------------------------------------
+    @testset "Traps" begin
+        @testset "a text round trip would lose precision" begin
+            # This is why the bridge never injects a PARI real into GP as a
+            # decimal string: PARI prints at the ambient `realprecision`, so
+            # a 512-bit real comes back as a 128-bit one with no diagnostic.
+            # The bridge's structural route keeps all 512 bits.
+            p = setprecision(() -> GP.mppi(), LibPARI.Gen, 512)
+            viatext = LibPARI.gp_eval(string(p))
+            @test precision(viatext) < precision(p)
+            @test !(viatext == p)
+            @test LibPARI.pari(to_giac(p)) == p
+            @test precision(LibPARI.pari(to_giac(p))) == precision(p)
+        end
+
+        @testset "gpolvar takes a keyword" begin
+            g = LibPARI.gp_eval("x^2+1")
+            @test string(GP.gpolvar(; x1 = g)) == "x"
+            @test_throws MethodError GP.gpolvar(g)
+        end
+    end
+
+    # ------------------------------------------------------------------
+    # The PARI stack must not grow across repeated crossings.
+    # ------------------------------------------------------------------
+    @testset "No PARI stack leak" begin
+        # Warm up first: the first crossing of each shape allocates Julia-side
+        # caches, and `_avma` is only meaningful once that has settled.
+        for _ = 1:10
+            LibPARI.pari(to_giac(LibPARI.gp_eval("(w+x)^2+3/4")))
+        end
+        GC.gc()
+        GC.gc()
+        before = LibPARI._avma()
+        for _ = 1:500
+            LibPARI.pari(to_giac(LibPARI.gp_eval("(w+x)^2+3/4")))
+        end
+        GC.gc()
+        GC.gc()
+        @test LibPARI._avma() == before
+    end
+
+    # ------------------------------------------------------------------
+    # Every method the bridge adds must carry a type it owns.
+    # ------------------------------------------------------------------
+    @testset "No type piracy" begin
+        ext = Base.get_extension(Giac, :GiacLibPARIExt)
+        @test !isnothing(ext)
+        for m in methods(Giac.to_giac)
+            m.module === ext || continue
+            @test any(t -> t === LibPARI.Gen, m.sig.parameters[2:end])
+        end
+        for m in methods(LibPARI.pari)
+            m.module === ext || continue
+            @test any(t -> t === GiacExpr, m.sig.parameters[2:end])
+        end
+    end
+end


### PR DESCRIPTION
Values can now cross between Giac and [PARI/GP](https://pari.math.u-bordeaux.fr/) through a new weak-dependency extension `GiacLibPARIExt` on [LibPARI.jl](https://github.com/s-celles/LibPARI.jl) 0.17.

```julia
using Giac, LibPARI

to_giac(gp_eval("(w+x)^2"))     # PARI -> Giac
pari(giac_eval("x^2+1"))        # Giac -> PARI
```

Two entry points, one per direction, matching the convention LibPARI's own Symbolics bridge established:

| Direction | Call | Owner of the name |
|---|---|---|
| PARI → Giac | `to_giac(g::LibPARI.Gen)` | Giac.jl |
| Giac → PARI | `LibPARI.pari(e::GiacExpr)` | LibPARI.jl |

The inward direction adds a method to LibPARI's own entry point rather than introducing a second name such as `to_pari`. That is not type piracy — LibPARI owns `pari`, Giac owns `GiacExpr` — and `Aqua.test_piracies` passes.

Giac.jl hosts the bridge because hosting means paying the CI cost, and `PARI_jll` (19 MB, ~13 deps) is far cheaper for Giac.jl to pull than `GIAC_jll` (73 MB, ~56 deps) would be the other way round.

## Contract

**Value-preserving and name-preserving; NOT representation-preserving.**

A PARI polynomial carries a variable *number* whose *priority* is process-global — `varhigher`/`varlower` change it for the whole process, so `(w+x)^2` prints as `x^2+2*w*x+w^2` or `w^2+2*x*w+x^2` depending on the ordering in force. Giac orders by its own rules. The variable *name* survives both crossings; the ordering does not.

So round trips are asserted with `==` (PARI's `gequal`) and **never** with `string`. The test file contains no textual comparison — that assertion would be red or flaky by construction.

## Coverage

**Outward:** `T_INT`, `T_FRAC`, `T_REAL`, `T_COMPLEX`, `T_POL`, `T_VEC`, `T_COL`, `T_VECSMALL`, `T_LIST`, `T_MAT`.
**Inward:** `INT`, `ZINT`, `FRAC`, `DOUBLE`, `REAL`, `CPLX`, `IDNT`, polynomial `SYMB`, `VECT`.

Everything else raises an `ArgumentError` **naming the tag** it could not translate:

```
julia> to_giac(gp_eval("3+O(5^4)"))
ERROR: ArgumentError: to_giac: no Giac counterpart for the PARI tag T_PADIC; the bridge
covers T_INT, T_FRAC, T_REAL, T_COMPLEX, T_POL, T_VEC, T_COL, T_VECSMALL, T_LIST and T_MAT
```

Notable refusals, each with a measured reason: `MOD`/`T_INTMOD` (Giac's `MOD` is opaque — `op`, `left`, `right`, `feuille` all return the `MOD` itself, so the residue and modulus are unrecoverable), `STRNG`/`T_STR` (LibPARI exposes no public accessor for a `t_STR`'s characters), rational functions, non-polynomial `SYMB`, constant `IDNT` (`pi` is an `IDNT` in Giac — a PARI variable named `pi` would be a lie), ragged vectors.

## Reals

Reals carry the **value's own precision** in both directions, never the ambient `setprecision(LibPARI.Gen, …)`, and never a printed decimal. The reason is measured:

```julia
p = setprecision(() -> LibPARI.PARI.mppi(), LibPARI.Gen, 512)
precision(p)                             # 512
precision(gp_eval(string(p)))            # 128  — no error, no warning
```

PARI prints at the current `realprecision`, so a text round trip silently truncates. That is asserted as a test, next to the assertion that the structural route keeps all 512 bits.

The one unavoidable textual step is reading a Giac `REAL` back out — the wrapper exposes `to_double` (lossy) and nothing for MPFR, and reaching into an undeclared libgiac C symbol is a call this project does not make. Giac's printer emits at the value's own precision, so the decimal is faithful and only the bit width must be recovered; the bridge recovers it by search and **verifies** it by re-encoding, raising rather than returning a quietly-rounded value. Pinned at 64/128/192/256/384/512/1024 bits, including inside containers.

## Two traps found at runtime

Neither would have been caught by reading:

1. **`Vec()` is not a one-element wrapper.** `Vec(x^2+1)` returns the coefficient vector and `Vec([1,2])` flattens, so it cannot start a vector fold — a first cut silently turned `[1, 3/4, x^2+1]` into a splice. `concat` (which treats a `t_POL` as a scalar) plus `vecextract` for the length-1 case is correct.
2. **Giac's `makevector` unwraps a lone vector argument**, which collapsed a one-row `t_MAT` into a `t_VEC` on the way back. `mid` does wrap.

Both are pinned by tests.

## Documented limitations

Each pinned by a test, so a change shows up here rather than in a user's results: `T_COL`/`T_VECSMALL`/`T_LIST` widen to `T_VEC` (elements preserved, container tag not); float tags do not survive; a `Gen` is not a `Number`; `gpolvar` takes a keyword; `gp_eval` does not honour `setprecision(LibPARI.Gen, …)` (documented, intended LibPARI behaviour, noted because it is easy to trip over when building a corpus).

## CI

A dedicated job (`.github/workflows/CI-LibPARI.yml`) builds a project containing **only** Giac and LibPARI and runs the bridge tests there. That is the part the main matrix cannot test: it fails if the bridge ever comes to depend on another extension having loaded first. The main matrix also covers the bridge via the `test` target — this job is the signal, not the only coverage.

## Testing

182 assertions in `test/test_libpari_ext.jl`. Full suite at this tip: 9495 pass, 2 pre-existing broken, Aqua 10/10 including `test_piracies`. Docs build with no new warnings.

## Registration

LibPARI 0.17.0 is in the General registry (JuliaRegistries/General#163021), so the weakdep resolves and Giac.jl remains registrable with this bridge.

---

**Part 3 of 3 in a stack.** Based on #43. **Merge this last** — it genuinely depends on #43: the bridge docs state that Giac's `to_julia` returns a `STRNG`'s characters, which is only true once #43 has landed.