### PR TITLE
ci: add Dependabot for the pinned GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# Keeps the pinned GitHub Actions current.
+#
+# CompatHelper watches Julia dependencies and never looks at workflows, so
+# without this nothing tracks the actions themselves. When this was written
+# four of the eight pinned actions were one to three majors behind:
+#
+#   actions/checkout                v4  ->  v7.0.1
+#   codecov/codecov-action          v4  ->  v7.0.0
+#   julia-actions/setup-julia       v2  ->  v3.0.2
+#   julia-actions/cache             v2  ->  v3.2.0
+#
+# Julia dependencies are deliberately absent: Dependabot has no Julia
+# ecosystem, and `[compat]` is CompatHelper's job.
+#
+# NOTE: `.gitignore` ignores everything by default and allows files back one
+# pattern at a time. This file needs its own entry — `!.github/dependabot.yml`
+# — because the allowlist's `.github/workflows/*.yml` does not reach the root
+# of `.github/`, and GitHub requires the config at exactly this path.
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    # One PR per action rather than a combined bump, so a failure is
+    # attributable to the action that caused it.
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 !docs/**
 
 !.github/
+!.github/dependabot.yml
 !.github/workflows/
 !.github/workflows/*.yml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Dependabot for the pinned GitHub Actions** (`.github/dependabot.yml`),
+  completing the automation added alongside CompatHelper. CompatHelper watches
+  Julia dependencies and never looks at workflows, so nothing tracked the
+  actions themselves — four of the eight pinned were one to three majors
+  behind when this was written: `actions/checkout` v4 → v7.0.1,
+  `codecov/codecov-action` v4 → v7.0.0, `julia-actions/setup-julia` v2 →
+  v3.0.2, `julia-actions/cache` v2 → v3.2.0. Configured for one PR per action
+  rather than a combined bump, so a failure is attributable to the action that
+  caused it.
+
+  This required one line in `.gitignore`. That file ignores everything by
+  default (`*`) and allows files back a pattern at a time; the allowlist
+  covered `.github/workflows/*.yml`, which does not reach the root of
+  `.github/`, and GitHub requires the Dependabot config at exactly
+  `.github/dependabot.yml`. The added line is a single negation for that one
+  path — no other file changes status.
+
 - **CompatHelper** and a **downgrade CI job**, closing two gaps in the
   repository's automation.
 


### PR DESCRIPTION
Completes the automation added with CompatHelper in #45, which deliberately left this out because it needs a `.gitignore` change.

## Why it is needed

CompatHelper watches Julia dependencies and **never looks at workflows**, so nothing tracks the actions themselves. Checking by hand — doing Dependabot's job manually — four of the eight pinned actions are one to three majors behind:

| Action | Pinned | Latest |
|---|---|---|
| `actions/checkout` | v4 | **v7.0.1** |
| `codecov/codecov-action` | v4 | **v7.0.0** |
| `julia-actions/setup-julia` | v2 | **v3.0.2** |
| `julia-actions/cache` | v2 | **v3.2.0** |
| `julia-actions/julia-buildpkg` | v1 | v1.7.0 (current major) |
| `julia-actions/julia-runtest` | v1 | v1.12.0 (current major) |
| `julia-actions/julia-downgrade-compat` | v2 | v2.7.0 (current major, fixed in #45) |

That same check caught a defect in #45 itself, where I had pinned the newly-added `julia-downgrade-compat` to a two-major-old `@v1`.

Configured for **one PR per action** rather than a combined bump, so a failure is attributable to the action that caused it. `setup-julia` v2→v3 in particular deserves to land on its own.

Julia dependencies are deliberately absent: Dependabot has no Julia ecosystem, and `[compat]` is CompatHelper's job.

## The `.gitignore` line

`.gitignore` ignores everything by default (`*` on line 2) and allows files back one pattern at a time. The allowlist covered:

```gitignore
!.github/
!.github/workflows/
!.github/workflows/*.yml
```

`.github/dependabot.yml` sits at the root of `.github/`, not under `workflows/`, so it fell through to the `*`. GitHub requires the config at exactly that path — there is no alternative location and no workaround.

The change is a single negation:

```diff
 !.github/
+!.github/dependabot.yml
 !.github/workflows/
 !.github/workflows/*.yml
```

Verified that nothing else changes status — `git status --ignored=no` reports only `.github/dependabot.yml` as newly visible.

## Testing

No code changes, so the suite is unaffected and was not re-run. The config's schema was validated locally: parses as `version: 2`, no unknown keys against the documented schema, required fields present, `package-ecosystem: github-actions`, `interval: weekly`.

Dependabot itself is a GitHub-hosted service with no local execution path, so the first real confirmation is GitHub accepting the file — visible under **Insights → Dependency graph → Dependabot** after merge. If the config were malformed it would show as an error there rather than failing CI.