### PR TITLE
fix(ci): pin julia-downgrade-compat back to v1 (main is red)

### DIFF
--- a/.github/workflows/CI-Downgrade.yml
+++ b/.github/workflows/CI-Downgrade.yml
@@ -44,26 +44,41 @@ jobs:
           version: '1.10'
           arch: x64
       - uses: julia-actions/cache@v2
-      # `mode: deps` scopes this to the hard `[deps]`. Test-only extras are
-      # excluded by construction — they are not dependencies — and so are the
-      # weak dependencies, which is deliberate rather than convenient.
+      # PINNED TO v1 ON PURPOSE. v2 exists and is newer, but it does not work
+      # for this package, and bumping it to v2 is what broke this job on main.
       #
-      # A weakdep floor is a *pairwise* promise: "this extension works against
-      # Symbolics 7.0". The default `alldeps` mode promotes every weakdep into
-      # one joint floor-resolve, forcing all five to their floors
-      # simultaneously — a combination that is unsatisfiable here and that no
-      # user meets, since you load one extension, not five floor-pinned ones
-      # together.
+      # v1 only rewrites `[compat]` entries. v2 additionally *promotes* the
+      # weak dependencies and the test extras into `[deps]` so it can perform
+      # one joint floor-resolve — and `Aqua.test_stale_deps`, which
+      # `runtests.jl` runs, then correctly reports ten packages sitting in
+      # `deps` that `using Giac` never loads:
       #
-      # `alldeps` with `no_promote` naming the specific offenders would give
-      # stronger coverage, and is the upgrade path once the weakdep floors
-      # have been audited one at a time.
+      #     Some package(s) in `deps` of Giac are not loaded via `using Giac`
+      #     * CSV  * Documenter  * ForwardDiff  * TermInterface
+      #     * ModelContextProtocol  * Symbolics  * Aqua  * LibPARI
+      #     * DataFrames  * MathJSON
       #
-      # `skip` still lists the standard libraries: their versions are tied to
-      # Julia itself and cannot be downgraded independently.
-      - uses: julia-actions/julia-downgrade-compat@v2
+      # `Aqua.test_persistent_tasks` fails as a knock-on, its subprocess
+      # unable to precompile against the rewritten project.
+      #
+      # v2's `no_promote` can exempt named extensions, but every weakdep here
+      # would have to be listed, which is v1's behaviour reached the long way
+      # round. Revisit only if the weakdep floors are ever audited so that a
+      # joint resolve becomes satisfiable — see the note below on why it is
+      # not today.
+      #
+      # SCOPE. The `skip` list leaves this testing the hard `[deps]` only.
+      # Standard libraries cannot be downgraded independently of Julia. A
+      # weakdep floor is a *pairwise* promise — "this extension works against
+      # Symbolics 7.0" — but `Pkg.test` resolves the whole test target at
+      # once, forcing all five weakdeps to their floors simultaneously, which
+      # is unsatisfiable here and is a situation no user meets: you load one
+      # extension, not five floor-pinned ones together.
+      - uses: julia-actions/julia-downgrade-compat@v1
         with:
-          mode: deps
-          skip: Libdl,LinearAlgebra,Random,Test
+          skip: >-
+            Libdl,LinearAlgebra,Random,Test,
+            Aqua,CSV,DataFrames,Documenter,ForwardDiff,
+            LibPARI,MathJSON,ModelContextProtocol,Symbolics,TermInterface
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1


### PR DESCRIPTION
**`main` is currently red** on the downgrade job. This reverts the cause.

## What happened

463ade2a bumped `julia-actions/julia-downgrade-compat` from `@v1` to `@v2`, on the reasoning that a brand-new workflow should not ship pinned to a two-major-old action. The reasoning was fine. **The change was not verified**, and v2 does considerably more than v1 — and what it does is wrong for this package.

The evidence is unambiguous; same branch, nothing else different:

| Run | Branch | Action | Result |
|---|---|---|---|
| [30669261012](https://github.com/s-celles/Giac.jl/actions/runs/30669261012) | `074-repo-bots` | **`@v1`** | ✅ success |
| [30669585522](https://github.com/s-celles/Giac.jl/actions/runs/30669585522) | `074-repo-bots` | **`@v2`** | ❌ failure |
| [30669696907](https://github.com/s-celles/Giac.jl/actions/runs/30669696907) | **`main`** | `@v2` | ❌ failure |
| [30670025231](https://github.com/s-celles/Giac.jl/actions/runs/30670025231) | `#44` | `@v2` | ❌ failure |

## Why v2 does not work here

v1 only rewrites `[compat]` entries. v2 additionally **promotes** the weak dependencies and the test extras into `[deps]`, so it can perform one joint floor-resolve. `Aqua.test_stale_deps` — which `runtests.jl` runs — then correctly reports ten packages sitting in `deps` that `using Giac` never loads:

```
Some package(s) in `deps` of Giac are not loaded via `using Giac`
  * CSV  * Documenter  * ForwardDiff  * TermInterface
  * ModelContextProtocol  * Symbolics  * Aqua  * LibPARI
  * DataFrames  * MathJSON
```

`Aqua.test_persistent_tasks` fails as a knock-on — its subprocess cannot precompile against the rewritten project (`done.log was not created`).

Note that the **package suite itself passed**; only Aqua failed. The floors are fine. This is purely the action mangling the project file.

v2's `no_promote` input can exempt named extensions, but every weakdep here would have to be listed — which is v1's behaviour reached the long way round. The workflow now carries a comment recording all of this, so the bump is not attempted again blindly.

## My mistake, precisely

The configuration was verified locally by simulating a **compat rewrite** — v1's semantics. I then switched the action to v2 and shipped on the strength of that earlier verification. Changing the thing under test after testing it is the whole error, and no amount of care in the surrounding reasoning compensates for it.

Worth noting the irony: the v2 bump came out of manually doing Dependabot's job and finding my own workflow pinned to an old major. The finding was correct; acting on it without re-verifying was not. It is a decent argument for letting Dependabot open that PR so CI decides, rather than hand-bumping.

## Effect on #44

[#44](https://github.com/s-celles/Giac.jl/pull/44) is failing for this reason and this reason alone — nothing to do with the LibPARI bridge. Once this merges, re-running #44's checks should clear it.