### PR TITLE
fix(ci): re-pin julia-downgrade-compat to v1, and tell Dependabot to leave it alone

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,18 @@ updates:
       prefix: "chore(ci)"
     labels:
       - dependencies
+    ignore:
+      # julia-downgrade-compat must stay on v1. v2 promotes the weak
+      # dependencies and test extras into `[deps]` to perform one joint
+      # floor-resolve, which makes `Aqua.test_stale_deps` report ten packages
+      # in `deps` that `using Giac` never loads, and takes
+      # `Aqua.test_persistent_tasks` down with it. See the comment in
+      # .github/workflows/CI-Downgrade.yml for the detail.
+      #
+      # This rule exists because a comment in the workflow is not binding:
+      # #47 pinned the action back to v1, and Dependabot re-applied the bump
+      # in #50 within hours, turning main red again for the same reason.
+      # Patch and minor updates within v1 are still welcome.
+      - dependency-name: julia-actions/julia-downgrade-compat
+        update-types:
+          - version-update:semver-major

--- a/.github/workflows/CI-Downgrade.yml
+++ b/.github/workflows/CI-Downgrade.yml
@@ -67,6 +67,11 @@ jobs:
       # joint resolve becomes satisfiable — see the note below on why it is
       # not today.
       #
+      # This comment is not enough on its own: Dependabot cannot read it, and
+      # re-applied the v2 bump in #50 within hours of #47 reverting it. The
+      # binding statement is the `ignore` rule for this action in
+      # `.github/dependabot.yml`; keep the two in step.
+      #
       # SCOPE. The `skip` list leaves this testing the hard `[deps]` only.
       # Standard libraries cannot be downgraded independently of Julia. A
       # weakdep floor is a *pairwise* promise — "this extension works against
@@ -74,7 +79,7 @@ jobs:
       # once, forcing all five weakdeps to their floors simultaneously, which
       # is unsatisfiable here and is a situation no user meets: you load one
       # extension, not five floor-pinned ones together.
-      - uses: julia-actions/julia-downgrade-compat@v2.6.2
+      - uses: julia-actions/julia-downgrade-compat@v1
         with:
           skip: >-
             Libdl,LinearAlgebra,Random,Test,


### PR DESCRIPTION
**`main` is red again**, for exactly the reason #47 diagnosed and fixed.

| PR | Commit | Change | Downgrade job |
|---|---|---|---|
| #47 | `72a153c5` | pin back to `@v1` | ✅ success ([30684096102](https://github.com/s-celles/Giac.jl/actions/runs/30684096102)) |
| #50 | `745493eb` | bump `v1` → `v2.6.2` | ❌ failing again |

Dependabot was doing its job. **The mistake was mine.** #47 recorded "PINNED TO v1 ON PURPOSE" as a comment in the workflow — and a comment is not binding on a bot that cannot read it. The binding mechanism is an `ignore` rule, which this PR adds:

```yaml
ignore:
  - dependency-name: julia-actions/julia-downgrade-compat
    update-types:
      - version-update:semver-major
```

Major bumps of that one action are ignored. Patch and minor updates within v1 still come through, and every other action is untouched — the four bumps in #48–#51 were all correct and stay.

## Why v2 cannot be used here

v1 only rewrites `[compat]`. v2 additionally **promotes** the weak dependencies and test extras into `[deps]` to perform one joint floor-resolve. `Aqua.test_stale_deps` then correctly reports ten packages in `deps` that `using Giac` never loads (CSV, Documenter, ForwardDiff, TermInterface, ModelContextProtocol, Symbolics, Aqua, LibPARI, DataFrames, MathJSON), and `Aqua.test_persistent_tasks` fails as a knock-on.

The package suite itself passes in both cases. This is purely the action rewriting the project file in a way Aqua then flags.

## #50 was actually worse than my own v2 attempt

Worth noting, because it explains why the failure came straight back rather than changing shape. My `463ade2a` at least paired `@v2` with `mode: deps`, which narrows what gets promoted. Dependabot bumped the version string and left the v1-shaped config, so the action ran in its **default `alldeps` mode** — promoting weakdeps and test extras with nothing holding them back.

That is the general hazard with a bot bumping an action across a major: it updates the version, never the configuration the new major expects.

## About #52

[#52](https://github.com/s-celles/Giac.jl/pull/52) (`setup-julia` 2 → 3) conflicts in `CI-Downgrade.yml` and `CI.yml`. It branched from `277e1734`, before #47 rewrote the downgrade block and before #48–#51 bumped four other actions in the same files. Merge this PR first, then comment `@dependabot rebase` on #52 — it will rebuild cleanly against the settled files rather than my having to hand-resolve a bot's branch.

`setup-julia` v2 → v3 is a genuine major and worth letting CI judge on its own; nothing in this PR pre-empts it.