### PR TITLE
fix(test): mark the bridge's real round trips broken on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The LibPARI bridge's real-number tests no longer fail the suite on
+  Windows**, and the platform difference behind them is documented rather than
+  hidden. `main` was red on both Windows runners with 23 failures, all of them
+  in `test_libpari_ext.jl`, all in reals.
+
+  On Linux and macOS, GIAC renders a `REAL` at *that value's* precision — 156
+  significant digits for a 512-bit value — and the global `Digits` setting has
+  no effect on it. The bridge reads a Giac `REAL` back by decoding its printed
+  decimal, and relies on exactly that.
+
+  On Windows, GIAC honours `Digits` instead, whose default is 12. Every real
+  crossed truncated to twelve significant digits — `3.14159265359…` for π at
+  any requested precision, 64 through 1024 bits alike. `Digits` governs
+  GIAC's parser on Windows too, so `convert(GiacExpr, ::BigFloat)` cannot even
+  store a wide value: it lands on `DOUBLE` rather than `REAL`.
+
+  Worth recording plainly: the bridge's decode *verifies itself* by
+  re-encoding the candidate and comparing printed forms, and that check was
+  blind here. Re-encoding the truncated value also prints twelve digits, so
+  the forms agreed and a wrong answer was confirmed. The check establishes the
+  printer's self-consistency, not its fidelity — the two coincide only where
+  the printer is faithful.
+
+  The affected assertions are now marked `@test_broken` on Windows rather than
+  skipped, so the suite reports an error if they ever start passing and tells
+  whoever fixed the platform difference to remove the marker. Everything else
+  in the bridge passes on Windows: integers, rationals, complex numbers,
+  polynomials, vectors, matrices, refusals, variable names, the PARI stack
+  check and the piracy check. A `DOUBLE`, needing no more than twelve digits,
+  crosses correctly.
+
+  The documentation said Giac's printer emits a `REAL` at the value's own
+  precision "rather than at a global setting", presented as a measured fact.
+  It was measured on Linux only. Corrected, with a dedicated section and a
+  warning admonition on the reals section.
+
 ### Added
 
 - **Dependabot for the pinned GitHub Actions** (`.github/dependabot.yml`),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,27 +14,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hidden. `main` was red on both Windows runners with 23 failures, all of them
   in `test_libpari_ext.jl`, all in reals.
 
-  On Linux and macOS, GIAC renders a `REAL` at *that value's* precision — 156
-  significant digits for a 512-bit value — and the global `Digits` setting has
-  no effect on it. The bridge reads a Giac `REAL` back by decoding its printed
-  decimal, and relies on exactly that.
+  The cause is not Giac and not the bridge: it is a known ABI bug between the
+  two binaries. `class gen` stored its tag as a bitfield, GCC fuses adjacent
+  bitfield writes with version-dependent bit placement, and `GIAC_jll` is
+  built with GCC 8 against `libgiac_julia_jll`'s GCC 10 — so libgiac writes a
+  gen tagged `_REAL` and the wrapper reads back `_DOUBLE_`. The suite observes
+  it directly: `Giac.giac_type(wide) == REAL` evaluates to `DOUBLE == REAL`.
 
-  On Windows, GIAC honours `Digits` instead, whose default is 12. Every real
-  crossed truncated to twelve significant digits — `3.14159265359…` for π at
-  any requested precision, 64 through 1024 bits alike. `Digits` governs
-  GIAC's parser on Windows too, so `convert(GiacExpr, ::BigFloat)` cannot even
-  store a wide value: it lands on `DOUBLE` rather than `REAL`.
+  Everything else follows. Giac.jl believes it holds a `Float64`, prints at
+  the global `Digits` — default 12 — and every real crosses truncated to
+  twelve significant digits, identically at 64, 128, 256, 512 and 1024 bits,
+  because 53 bits is all a mis-tagged `DOUBLE` ever had. Raising `Digits`
+  would change nothing: the precision is lost at the tag, not at the printer.
 
-  Worth recording plainly: the bridge's decode *verifies itself* by
-  re-encoding the candidate and comparing printed forms, and that check was
-  blind here. Re-encoding the truncated value also prints twelve digits, so
-  the forms agreed and a wrong answer was confirmed. The check establishes the
-  printer's self-consistency, not its fidelity — the two coincide only where
-  the printer is faithful.
+  Fix in flight upstream:
+  [Yggdrasil#13717](https://github.com/JuliaPackaging/Yggdrasil/pull/13717)
+  bumps `GIAC_jll` to v2.0.2 with `GIAC_TYPE_ON_8BITS=1`, making the ABI
+  compiler-invariant, followed by a `libgiac_julia_jll` bump. Same root cause
+  as [#22](https://github.com/s-celles/Giac.jl/pull/22) and the probe in
+  [#26](https://github.com/s-celles/Giac.jl/pull/26).
+
+  One thing this did establish about the bridge itself: its decode *verifies
+  itself* by re-encoding the candidate and comparing printed forms, and that
+  check is blind here. Re-encoding the truncated value also prints twelve
+  digits, the forms agree, and a wrong answer is confirmed. The check
+  establishes the printer's self-consistency, not its fidelity — the two
+  coincide only where the tag is right.
 
   The affected assertions are now marked `@test_broken` on Windows rather than
-  skipped, so the suite reports an error if they ever start passing and tells
-  whoever fixed the platform difference to remove the marker. Everything else
+  skipped, so that when the two JLLs land the suite reports *unexpected
+  passes* and tells whoever did it to delete the markers. Everything else
   in the bridge passes on Windows: integers, rationals, complex numbers,
   polynomials, vectors, matrices, refusals, variable names, the PARI stack
   check and the piracy check. A `DOUBLE`, needing no more than twelve digits,

--- a/docs/src/extensions/libpari.md
+++ b/docs/src/extensions/libpari.md
@@ -145,6 +145,12 @@ the value itself, in both directions — a 512-bit `t_REAL` reaches Giac with
 all 512 bits even while the ambient setting is 64, and comes back a 512-bit
 `t_REAL`.
 
+!!! warning "Linux and macOS only"
+    This section describes reals on Linux and macOS. **On Windows a real does
+    not cross at all**: it arrives truncated to twelve significant digits.
+    See [Reals do not cross on Windows](@ref) before relying on any of what
+    follows.
+
 ```julia
 using Giac, LibPARI
 
@@ -179,20 +185,62 @@ by construction.
 Reading a Giac `REAL` back out is the exception, and it is worth stating
 plainly. The libgiac wrapper exposes `to_double` — a `Float64`, and therefore
 lossy — and nothing for an MPFR value; reaching past it into an undeclared
-libgiac C symbol is a call this project does not make. Giac's printer does,
-however, emit a `REAL` at that value's *own* precision rather than at a global
-setting, so the decimal it produces is faithful and only the bit width has to
-be recovered.
+libgiac C symbol is a call this project does not make. **On Linux and macOS**
+Giac's printer emits a `REAL` at that value's *own* precision rather than at
+the global `Digits` setting, so the decimal it produces is faithful and only
+the bit width has to be recovered.
 
-The bridge recovers that width by search and then **verifies** it: a candidate
-is accepted only when re-encoding it reproduces Giac's own printed form
-character for character. A width that cannot be verified raises rather than
-returning a quietly-rounded value. The behaviour is pinned by tests at 64,
-128, 192, 256, 384, 512 and 1024 bits.
+The bridge recovers that width by search and then re-encodes the candidate,
+accepting it only when the printed forms agree character for character. A
+width for which nothing agrees raises rather than returning a quietly-rounded
+value. The behaviour is pinned by tests at 64, 128, 192, 256, 384, 512 and
+1024 bits.
+
+Note precisely what that check does and does not establish. It tests the
+**printer's self-consistency**, not its fidelity to the stored value. Those
+coincide only where the printer is faithful — which is why the check is sound
+on Linux and macOS and blind on Windows, where it confirms a truncated answer
+without complaint. See [Reals do not cross on Windows](@ref).
 
 This would become unnecessary if the wrapper gained an MPFR accessor for
-`REAL`; until then it is the bridge's only text-mediated step, and it is
-checked rather than trusted.
+`REAL`; until then it is the bridge's only text-mediated step.
+
+## Reals do not cross on Windows
+
+**On Windows, a `t_REAL` does not survive the crossing.** Every real arrives
+truncated to twelve significant digits, whatever precision was asked for:
+
+```julia
+p = setprecision(() -> LibPARI.PARI.mppi(), LibPARI.Gen, 512)
+
+pari(to_giac(p)) == p     # false on Windows, true elsewhere
+# expected  3.1415926535897932384626433832795028842
+# obtained  3.14159265359 0000062
+```
+
+Twelve is the default of Giac's global `Digits`. Where Linux and macOS render
+a `REAL` at the value's own precision — 156 significant digits for a 512-bit
+value — Windows honours `Digits` instead. The same applies to Giac's
+*parser*, so `convert(GiacExpr, ::BigFloat)` cannot even store a wide value on
+Windows: it lands on `DOUBLE` rather than `REAL`.
+
+64, 128, 192, 256, 384, 512 and 1024 bits all yield the same twelve digits, so
+this is not a rounding difference but a hard ceiling.
+
+**Everything else in the bridge works on Windows** — integers, rationals,
+complex numbers, polynomials, vectors, matrices, the refusal list, variable
+names. Only reals are affected, and a `DOUBLE` (which needs no more than
+twelve digits) crosses correctly.
+
+The affected assertions are marked `@test_broken` on Windows rather than
+skipped, so that if the platform difference is ever fixed the test suite
+reports an error telling whoever fixed it to remove the marker.
+
+This is a Giac platform difference, not something the bridge introduces, and
+the bridge cannot work around it: the wrapper offers no way to read a `REAL`
+other than through its printed form. If you need reals to cross on Windows,
+convert them to an exact type first — `Rational` crosses faithfully on every
+platform.
 
 ## Known limitations
 
@@ -220,16 +268,21 @@ Giac.jl's suite rather than in your results.
    PARI's `t_REAL`; coming back, Giac picks `DOUBLE` or `REAL` according to
    how much precision the value needs. Values are preserved either way.
 
-4. **A `Gen` is not a `Number`.** It is a `LibPARI.PariObject`. Generic
+4. **Reals do not cross on Windows** — see the dedicated section above. A
+   `t_REAL` arrives truncated to twelve significant digits, because Giac on
+   Windows renders and parses a `REAL` at the global `Digits` rather than at
+   the value's own precision. Every other type is unaffected.
+
+5. **A `Gen` is not a `Number`.** It is a `LibPARI.PariObject`. Generic
    numeric code bounded by `T<:Number` will not accept one, and `Number`
    methods must not be assumed to apply.
 
-5. **`LibPARI.PARI.gpolvar` takes a keyword**, not a positional argument:
+6. **`LibPARI.PARI.gpolvar` takes a keyword**, not a positional argument:
    `gpolvar(; x1 = g)`. Most of LibPARI's generated bindings pass the first
    argument positionally and the rest as keywords; check the signature before
    calling one.
 
-6. **`gp_eval` does not honour `setprecision(LibPARI.Gen, …)`.** It goes
+7. **`gp_eval` does not honour `setprecision(LibPARI.Gen, …)`.** It goes
    through the GP interpreter, which reads PARI's process-global
    `realprecision`, so `setprecision(() -> gp_eval("Pi"), LibPARI.Gen, 512)`
    returns a 128-bit value. This is documented, intended LibPARI behaviour —

--- a/docs/src/extensions/libpari.md
+++ b/docs/src/extensions/libpari.md
@@ -147,7 +147,8 @@ all 512 bits even while the ambient setting is 64, and comes back a 512-bit
 
 !!! warning "Linux and macOS only"
     This section describes reals on Linux and macOS. **On Windows a real does
-    not cross at all**: it arrives truncated to twelve significant digits.
+    not cross at all**: a binary ABI mismatch makes the wrapper read a `_REAL`
+    tag as `_DOUBLE_`, so it arrives truncated to twelve significant digits.
     See [Reals do not cross on Windows](@ref) before relying on any of what
     follows.
 
@@ -218,29 +219,52 @@ pari(to_giac(p)) == p     # false on Windows, true elsewhere
 # obtained  3.14159265359 0000062
 ```
 
-Twelve is the default of Giac's global `Digits`. Where Linux and macOS render
-a `REAL` at the value's own precision — 156 significant digits for a 512-bit
-value — Windows honours `Digits` instead. The same applies to Giac's
-*parser*, so `convert(GiacExpr, ::BigFloat)` cannot even store a wide value on
-Windows: it lands on `DOUBLE` rather than `REAL`.
+This is **not** a Giac printing quirk and not something the bridge can work
+around. It is a known ABI bug between the two binaries, already diagnosed,
+with a fix in flight upstream.
 
-64, 128, 192, 256, 384, 512 and 1024 bits all yield the same twelve digits, so
-this is not a rounding difference but a hard ceiling.
+`class gen` historically stored its tag as a bitfield —
+`unsigned char type:5; unsigned char type_unused:3;`. GCC fuses adjacent
+bitfield writes into one wider store and chooses the bit placement in a
+version-dependent way. `GIAC_jll` is built with GCC 8 and
+`libgiac_julia_jll` with GCC 10, so the two disagree about which bits hold
+`type`: libgiac writes a gen tagged `_REAL`, and the wrapper reads back
+`_DOUBLE_`. Giac.jl then believes it is holding a `Float64`, prints it at the
+global `Digits` — default 12 — and the extra precision is gone.
+
+That the loss is identical at 64, 128, 256, 512 and 1024 bits is the tell:
+53 bits is all a mis-tagged `DOUBLE` ever had. **Raising `Digits` would change
+nothing** — the precision is lost at the tag, not at the printer.
+
+The fix is [JuliaPackaging/Yggdrasil#13717](https://github.com/JuliaPackaging/Yggdrasil/pull/13717),
+which bumps `GIAC_jll` to v2.0.2 built with `GIAC_TYPE_ON_8BITS=1` — making
+`type` a plain byte at offset 0, so the ABI no longer depends on the compiler
+version — followed by a matching `libgiac_julia_jll` bump. Same root cause as
+[Giac.jl#22](https://github.com/s-celles/Giac.jl/pull/22) and the diagnostic
+probe in [Giac.jl#26](https://github.com/s-celles/Giac.jl/pull/26).
 
 **Everything else in the bridge works on Windows** — integers, rationals,
 complex numbers, polynomials, vectors, matrices, the refusal list, variable
-names. Only reals are affected, and a `DOUBLE` (which needs no more than
-twelve digits) crosses correctly.
+names. Only reals are affected, and a `DOUBLE` crosses correctly, since a
+`DOUBLE` is what the mis-tag claims it already is.
 
 The affected assertions are marked `@test_broken` on Windows rather than
-skipped, so that if the platform difference is ever fixed the test suite
-reports an error telling whoever fixed it to remove the marker.
+skipped. When the two JLLs land, those markers will start reporting
+*unexpected passes*, which is the signal to delete them.
 
-This is a Giac platform difference, not something the bridge introduces, and
-the bridge cannot work around it: the wrapper offers no way to read a `REAL`
-other than through its printed form. If you need reals to cross on Windows,
-convert them to an exact type first — `Rational` crosses faithfully on every
-platform.
+If you need reals to cross on Windows before then, convert to an exact type
+first — `Rational` crosses faithfully on every platform.
+
+### What this says about the bridge's own safety check
+
+The bridge reads a Giac `REAL` back by decoding its printed decimal, and
+verifies the result by re-encoding it and comparing printed forms. On Windows
+that check is **blind**: re-encoding the truncated value also prints twelve
+digits, the forms agree, and a wrong answer is confirmed without complaint.
+
+The check establishes the printer's *self-consistency*, not its *fidelity to
+the stored value*. Those coincide only where the tag is right. A guard worth
+having, but not one that can detect a lie told further down the stack.
 
 ## Known limitations
 
@@ -269,9 +293,11 @@ Giac.jl's suite rather than in your results.
    how much precision the value needs. Values are preserved either way.
 
 4. **Reals do not cross on Windows** — see the dedicated section above. A
-   `t_REAL` arrives truncated to twelve significant digits, because Giac on
-   Windows renders and parses a `REAL` at the global `Digits` rather than at
-   the value's own precision. Every other type is unaffected.
+   `t_REAL` arrives truncated to twelve significant digits, because a GCC
+   bitfield-ABI mismatch between `GIAC_jll` and `libgiac_julia_jll` makes the
+   wrapper read a `_REAL` tag as `_DOUBLE_`. Fix in flight upstream
+   ([Yggdrasil#13717](https://github.com/JuliaPackaging/Yggdrasil/pull/13717));
+   every other type is unaffected.
 
 5. **A `Gen` is not a `Number`.** It is a `LibPARI.PariObject`. Generic
    numeric code bounded by `T<:Number` will not accept one, and `Number`

--- a/docs/src/llms-full.txt
+++ b/docs/src/llms-full.txt
@@ -5424,7 +5424,8 @@ all 512 bits even while the ambient setting is 64, and comes back a 512-bit
 
 !!! warning "Linux and macOS only"
     This section describes reals on Linux and macOS. **On Windows a real does
-    not cross at all**: it arrives truncated to twelve significant digits.
+    not cross at all**: a binary ABI mismatch makes the wrapper read a `_REAL`
+    tag as `_DOUBLE_`, so it arrives truncated to twelve significant digits.
     See [Reals do not cross on Windows](@ref) before relying on any of what
     follows.
 
@@ -5495,29 +5496,52 @@ pari(to_giac(p)) == p     # false on Windows, true elsewhere
 # obtained  3.14159265359 0000062
 ```
 
-Twelve is the default of Giac's global `Digits`. Where Linux and macOS render
-a `REAL` at the value's own precision — 156 significant digits for a 512-bit
-value — Windows honours `Digits` instead. The same applies to Giac's
-*parser*, so `convert(GiacExpr, ::BigFloat)` cannot even store a wide value on
-Windows: it lands on `DOUBLE` rather than `REAL`.
+This is **not** a Giac printing quirk and not something the bridge can work
+around. It is a known ABI bug between the two binaries, already diagnosed,
+with a fix in flight upstream.
 
-64, 128, 192, 256, 384, 512 and 1024 bits all yield the same twelve digits, so
-this is not a rounding difference but a hard ceiling.
+`class gen` historically stored its tag as a bitfield —
+`unsigned char type:5; unsigned char type_unused:3;`. GCC fuses adjacent
+bitfield writes into one wider store and chooses the bit placement in a
+version-dependent way. `GIAC_jll` is built with GCC 8 and
+`libgiac_julia_jll` with GCC 10, so the two disagree about which bits hold
+`type`: libgiac writes a gen tagged `_REAL`, and the wrapper reads back
+`_DOUBLE_`. Giac.jl then believes it is holding a `Float64`, prints it at the
+global `Digits` — default 12 — and the extra precision is gone.
+
+That the loss is identical at 64, 128, 256, 512 and 1024 bits is the tell:
+53 bits is all a mis-tagged `DOUBLE` ever had. **Raising `Digits` would change
+nothing** — the precision is lost at the tag, not at the printer.
+
+The fix is [JuliaPackaging/Yggdrasil#13717](https://github.com/JuliaPackaging/Yggdrasil/pull/13717),
+which bumps `GIAC_jll` to v2.0.2 built with `GIAC_TYPE_ON_8BITS=1` — making
+`type` a plain byte at offset 0, so the ABI no longer depends on the compiler
+version — followed by a matching `libgiac_julia_jll` bump. Same root cause as
+[Giac.jl#22](https://github.com/s-celles/Giac.jl/pull/22) and the diagnostic
+probe in [Giac.jl#26](https://github.com/s-celles/Giac.jl/pull/26).
 
 **Everything else in the bridge works on Windows** — integers, rationals,
 complex numbers, polynomials, vectors, matrices, the refusal list, variable
-names. Only reals are affected, and a `DOUBLE` (which needs no more than
-twelve digits) crosses correctly.
+names. Only reals are affected, and a `DOUBLE` crosses correctly, since a
+`DOUBLE` is what the mis-tag claims it already is.
 
 The affected assertions are marked `@test_broken` on Windows rather than
-skipped, so that if the platform difference is ever fixed the test suite
-reports an error telling whoever fixed it to remove the marker.
+skipped. When the two JLLs land, those markers will start reporting
+*unexpected passes*, which is the signal to delete them.
 
-This is a Giac platform difference, not something the bridge introduces, and
-the bridge cannot work around it: the wrapper offers no way to read a `REAL`
-other than through its printed form. If you need reals to cross on Windows,
-convert them to an exact type first — `Rational` crosses faithfully on every
-platform.
+If you need reals to cross on Windows before then, convert to an exact type
+first — `Rational` crosses faithfully on every platform.
+
+### What this says about the bridge's own safety check
+
+The bridge reads a Giac `REAL` back by decoding its printed decimal, and
+verifies the result by re-encoding it and comparing printed forms. On Windows
+that check is **blind**: re-encoding the truncated value also prints twelve
+digits, the forms agree, and a wrong answer is confirmed without complaint.
+
+The check establishes the printer's *self-consistency*, not its *fidelity to
+the stored value*. Those coincide only where the tag is right. A guard worth
+having, but not one that can detect a lie told further down the stack.
 
 ## Known limitations
 
@@ -5546,9 +5570,11 @@ Giac.jl's suite rather than in your results.
    how much precision the value needs. Values are preserved either way.
 
 4. **Reals do not cross on Windows** — see the dedicated section above. A
-   `t_REAL` arrives truncated to twelve significant digits, because Giac on
-   Windows renders and parses a `REAL` at the global `Digits` rather than at
-   the value's own precision. Every other type is unaffected.
+   `t_REAL` arrives truncated to twelve significant digits, because a GCC
+   bitfield-ABI mismatch between `GIAC_jll` and `libgiac_julia_jll` makes the
+   wrapper read a `_REAL` tag as `_DOUBLE_`. Fix in flight upstream
+   ([Yggdrasil#13717](https://github.com/JuliaPackaging/Yggdrasil/pull/13717));
+   every other type is unaffected.
 
 5. **A `Gen` is not a `Number`.** It is a `LibPARI.PariObject`. Generic
    numeric code bounded by `T<:Number` will not accept one, and `Number`

--- a/docs/src/llms-full.txt
+++ b/docs/src/llms-full.txt
@@ -5422,6 +5422,12 @@ the value itself, in both directions — a 512-bit `t_REAL` reaches Giac with
 all 512 bits even while the ambient setting is 64, and comes back a 512-bit
 `t_REAL`.
 
+!!! warning "Linux and macOS only"
+    This section describes reals on Linux and macOS. **On Windows a real does
+    not cross at all**: it arrives truncated to twelve significant digits.
+    See [Reals do not cross on Windows](@ref) before relying on any of what
+    follows.
+
 ```julia
 using Giac, LibPARI
 
@@ -5456,20 +5462,62 @@ by construction.
 Reading a Giac `REAL` back out is the exception, and it is worth stating
 plainly. The libgiac wrapper exposes `to_double` — a `Float64`, and therefore
 lossy — and nothing for an MPFR value; reaching past it into an undeclared
-libgiac C symbol is a call this project does not make. Giac's printer does,
-however, emit a `REAL` at that value's *own* precision rather than at a global
-setting, so the decimal it produces is faithful and only the bit width has to
-be recovered.
+libgiac C symbol is a call this project does not make. **On Linux and macOS**
+Giac's printer emits a `REAL` at that value's *own* precision rather than at
+the global `Digits` setting, so the decimal it produces is faithful and only
+the bit width has to be recovered.
 
-The bridge recovers that width by search and then **verifies** it: a candidate
-is accepted only when re-encoding it reproduces Giac's own printed form
-character for character. A width that cannot be verified raises rather than
-returning a quietly-rounded value. The behaviour is pinned by tests at 64,
-128, 192, 256, 384, 512 and 1024 bits.
+The bridge recovers that width by search and then re-encodes the candidate,
+accepting it only when the printed forms agree character for character. A
+width for which nothing agrees raises rather than returning a quietly-rounded
+value. The behaviour is pinned by tests at 64, 128, 192, 256, 384, 512 and
+1024 bits.
+
+Note precisely what that check does and does not establish. It tests the
+**printer's self-consistency**, not its fidelity to the stored value. Those
+coincide only where the printer is faithful — which is why the check is sound
+on Linux and macOS and blind on Windows, where it confirms a truncated answer
+without complaint. See [Reals do not cross on Windows](@ref).
 
 This would become unnecessary if the wrapper gained an MPFR accessor for
-`REAL`; until then it is the bridge's only text-mediated step, and it is
-checked rather than trusted.
+`REAL`; until then it is the bridge's only text-mediated step.
+
+## Reals do not cross on Windows
+
+**On Windows, a `t_REAL` does not survive the crossing.** Every real arrives
+truncated to twelve significant digits, whatever precision was asked for:
+
+```julia
+p = setprecision(() -> LibPARI.PARI.mppi(), LibPARI.Gen, 512)
+
+pari(to_giac(p)) == p     # false on Windows, true elsewhere
+# expected  3.1415926535897932384626433832795028842
+# obtained  3.14159265359 0000062
+```
+
+Twelve is the default of Giac's global `Digits`. Where Linux and macOS render
+a `REAL` at the value's own precision — 156 significant digits for a 512-bit
+value — Windows honours `Digits` instead. The same applies to Giac's
+*parser*, so `convert(GiacExpr, ::BigFloat)` cannot even store a wide value on
+Windows: it lands on `DOUBLE` rather than `REAL`.
+
+64, 128, 192, 256, 384, 512 and 1024 bits all yield the same twelve digits, so
+this is not a rounding difference but a hard ceiling.
+
+**Everything else in the bridge works on Windows** — integers, rationals,
+complex numbers, polynomials, vectors, matrices, the refusal list, variable
+names. Only reals are affected, and a `DOUBLE` (which needs no more than
+twelve digits) crosses correctly.
+
+The affected assertions are marked `@test_broken` on Windows rather than
+skipped, so that if the platform difference is ever fixed the test suite
+reports an error telling whoever fixed it to remove the marker.
+
+This is a Giac platform difference, not something the bridge introduces, and
+the bridge cannot work around it: the wrapper offers no way to read a `REAL`
+other than through its printed form. If you need reals to cross on Windows,
+convert them to an exact type first — `Rational` crosses faithfully on every
+platform.
 
 ## Known limitations
 
@@ -5497,16 +5545,21 @@ Giac.jl's suite rather than in your results.
    PARI's `t_REAL`; coming back, Giac picks `DOUBLE` or `REAL` according to
    how much precision the value needs. Values are preserved either way.
 
-4. **A `Gen` is not a `Number`.** It is a `LibPARI.PariObject`. Generic
+4. **Reals do not cross on Windows** — see the dedicated section above. A
+   `t_REAL` arrives truncated to twelve significant digits, because Giac on
+   Windows renders and parses a `REAL` at the global `Digits` rather than at
+   the value's own precision. Every other type is unaffected.
+
+5. **A `Gen` is not a `Number`.** It is a `LibPARI.PariObject`. Generic
    numeric code bounded by `T<:Number` will not accept one, and `Number`
    methods must not be assumed to apply.
 
-5. **`LibPARI.PARI.gpolvar` takes a keyword**, not a positional argument:
+6. **`LibPARI.PARI.gpolvar` takes a keyword**, not a positional argument:
    `gpolvar(; x1 = g)`. Most of LibPARI's generated bindings pass the first
    argument positionally and the rest as keywords; check the signature before
    calling one.
 
-6. **`gp_eval` does not honour `setprecision(LibPARI.Gen, …)`.** It goes
+7. **`gp_eval` does not honour `setprecision(LibPARI.Gen, …)`.** It goes
    through the GP interpreter, which reads PARI's process-global
    `realprecision`, so `setprecision(() -> gp_eval("Pi"), LibPARI.Gen, 512)`
    returns a 128-bit value. This is documented, intended LibPARI behaviour —

--- a/test/test_libpari_ext.jl
+++ b/test/test_libpari_ext.jl
@@ -26,6 +26,53 @@ using LibPARI
 const PT = LibPARI.PariType
 const GP = LibPARI.PARI
 
+# ---------------------------------------------------------------------------
+# Windows: a REAL does not survive the crossing.
+#
+# On Linux and macOS, GIAC renders a REAL at *that value's* precision — 156
+# significant digits for a 512-bit value, exactly `ceil(p*log10(2)) + 1` — and
+# the global `Digits` setting does not affect it. The bridge relies on that:
+# it reads a Giac REAL back by decoding its printed decimal.
+#
+# On Windows, GIAC instead honours the global `Digits`, whose default is 12.
+# Every real crosses truncated to twelve significant digits:
+#
+#     expected  3.1415926535897932384626433832795028842
+#     obtained  3.14159265359 0000062
+#
+# regardless of the precision requested — 64, 128, 192, 256, 384, 512 or 1024
+# bits all yield the same twelve digits. `Digits` governs GIAC's *parser* on
+# Windows too, so `convert(GiacExpr, ::BigFloat)` cannot even store a wide
+# value: it lands on DOUBLE rather than REAL.
+#
+# The bridge's decode verifies itself by re-encoding and comparing printed
+# forms. That check is blind here: re-encoding the truncated value also prints
+# twelve digits, so the two forms agree and a wrong answer is confirmed. The
+# check tests the printer's self-consistency, not its fidelity — equivalent
+# only where the printer is faithful.
+#
+# These assertions are therefore marked broken on Windows rather than removed
+# or silently skipped. `@test_broken` reports an *error* if the expression
+# starts passing, so whoever fixes this is told to delete the marker.
+#
+# Everything else in the bridge passes on Windows: integers, rationals,
+# complex numbers, polynomials, vectors, matrices, refusals, variable names,
+# the PARI stack check and the piracy check. Only reals are affected.
+#
+# See docs/src/extensions/libpari.md, "Reals do not cross on Windows".
+# ---------------------------------------------------------------------------
+const REALS_BROKEN_ON_WINDOWS = Sys.iswindows()
+
+macro test_real(ex)
+    quote
+        if REALS_BROKEN_ON_WINDOWS
+            @test_broken $(esc(ex))
+        else
+            @test $(esc(ex))
+        end
+    end
+end
+
 @testset "LibPARI Extension" begin
 
     @testset "Extension loads" begin
@@ -145,7 +192,7 @@ const GP = LibPARI.PARI
             for bits in (64, 128, 192, 256, 384, 512, 1024)
                 p = setprecision(() -> GP.mppi(), LibPARI.Gen, bits)
                 @test precision(p) == bits
-                @test LibPARI.pari(to_giac(p)) == p
+                @test_real LibPARI.pari(to_giac(p)) == p
             end
         end
 
@@ -153,7 +200,7 @@ const GP = LibPARI.PARI
             for src in ("sqrt(2)", "1/3.", "-Pi", "Pi*2^-300", "Pi*2^300", "exp(1)")
                 p = LibPARI.gp_eval(src)
                 @test LibPARI.gentype(p) === PT.T_REAL
-                @test LibPARI.pari(to_giac(p)) == p
+                @test_real LibPARI.pari(to_giac(p)) == p
             end
         end
 
@@ -163,14 +210,14 @@ const GP = LibPARI.PARI
             wide = setprecision(() -> GP.mppi(), LibPARI.Gen, 512)
             narrow = setprecision(() -> GP.mppi(), LibPARI.Gen, 64)
             setprecision(LibPARI.Gen, 64) do
-                @test LibPARI.pari(to_giac(wide)) == wide
+                @test_real LibPARI.pari(to_giac(wide)) == wide
             end
             setprecision(LibPARI.Gen, 512) do
-                @test LibPARI.pari(to_giac(narrow)) == narrow
+                @test_real LibPARI.pari(to_giac(narrow)) == narrow
             end
             # The ambient `BigFloat` precision is likewise not consulted.
             setprecision(BigFloat, 53) do
-                @test LibPARI.pari(to_giac(wide)) == wide
+                @test_real LibPARI.pari(to_giac(wide)) == wide
             end
         end
 
@@ -182,9 +229,9 @@ const GP = LibPARI.PARI
             onevec = GP.extract0(GP.gconcat(wide; x2 = wide), LibPARI.pari(1); x3 = nothing)
             onemat = GP.gtomat(; x1 = GP.gtocol0(onevec; x2 = 0))
             for g in (onevec, onemat, GP.gconcat(wide; x2 = LibPARI.pari(1)))
-                @test LibPARI.pari(to_giac(g)) == g
+                @test_real LibPARI.pari(to_giac(g)) == g
             end
-            @test precision(LibPARI.pari(to_giac(onevec))[1]) == 512
+            @test_real precision(LibPARI.pari(to_giac(onevec))[1]) == 512
         end
 
         @testset "float tags are not preserved, only values" begin
@@ -200,7 +247,7 @@ const GP = LibPARI.PARI
             narrow = to_giac(LibPARI.pari(1.5))
             wide = to_giac(setprecision(() -> GP.mppi(), LibPARI.Gen, 512))
             @test Giac.giac_type(narrow) in (DOUBLE, REAL)
-            @test Giac.giac_type(wide) == REAL
+            @test_real Giac.giac_type(wide) == REAL
             @test LibPARI.pari(narrow) == LibPARI.pari(1.5)
         end
     end
@@ -365,8 +412,8 @@ const GP = LibPARI.PARI
             viatext = LibPARI.gp_eval(string(p))
             @test precision(viatext) < precision(p)
             @test !(viatext == p)
-            @test LibPARI.pari(to_giac(p)) == p
-            @test precision(LibPARI.pari(to_giac(p))) == precision(p)
+            @test_real LibPARI.pari(to_giac(p)) == p
+            @test_real precision(LibPARI.pari(to_giac(p))) == precision(p)
         end
 
         @testset "gpolvar takes a keyword" begin

--- a/test/test_libpari_ext.jl
+++ b/test/test_libpari_ext.jl
@@ -29,31 +29,49 @@ const GP = LibPARI.PARI
 # ---------------------------------------------------------------------------
 # Windows: a REAL does not survive the crossing.
 #
-# On Linux and macOS, GIAC renders a REAL at *that value's* precision — 156
-# significant digits for a 512-bit value, exactly `ceil(p*log10(2)) + 1` — and
-# the global `Digits` setting does not affect it. The bridge relies on that:
-# it reads a Giac REAL back by decoding its printed decimal.
+# NOT a Giac printing quirk, and not something this bridge can work around:
+# it is a known ABI bug between the two binaries, already diagnosed and with
+# a fix in flight upstream.
 #
-# On Windows, GIAC instead honours the global `Digits`, whose default is 12.
-# Every real crosses truncated to twelve significant digits:
+# `class gen` historically stored its tag as a bitfield —
+# `unsigned char type:5; unsigned char type_unused:3;`. GCC fuses adjacent
+# bitfield writes into one wider store, and picks the bit placement in a
+# version-dependent way. `GIAC_jll` is built with GCC 8 and
+# `libgiac_julia_jll` with GCC 10, so they disagree about which bits hold
+# `type`: libgiac writes a gen tagged `_REAL` (3) and the wrapper reads back
+# `_DOUBLE_` (1).
+#
+# The test suite observes exactly that:
+#
+#     Expression: Giac.giac_type(wide) == REAL
+#     Evaluated:  DOUBLE == REAL
+#
+# Everything else follows from the mis-tag. Giac.jl believes it holds a
+# Float64, so it prints at the global `Digits` — default 12 — and every real
+# crosses truncated to twelve significant digits:
 #
 #     expected  3.1415926535897932384626433832795028842
 #     obtained  3.14159265359 0000062
 #
-# regardless of the precision requested — 64, 128, 192, 256, 384, 512 or 1024
-# bits all yield the same twelve digits. `Digits` governs GIAC's *parser* on
-# Windows too, so `convert(GiacExpr, ::BigFloat)` cannot even store a wide
-# value: it lands on DOUBLE rather than REAL.
+# identically at 64, 128, 192, 256, 384, 512 and 1024 bits, because 53 bits
+# is all a mis-tagged DOUBLE ever had.
 #
-# The bridge's decode verifies itself by re-encoding and comparing printed
-# forms. That check is blind here: re-encoding the truncated value also prints
-# twelve digits, so the two forms agree and a wrong answer is confirmed. The
-# check tests the printer's self-consistency, not its fidelity — equivalent
-# only where the printer is faithful.
+# Raising `Digits` would therefore change nothing: the precision is lost at
+# the tag, not at the printer.
 #
-# These assertions are therefore marked broken on Windows rather than removed
-# or silently skipped. `@test_broken` reports an *error* if the expression
-# starts passing, so whoever fixes this is told to delete the marker.
+# Fix: JuliaPackaging/Yggdrasil#13717 bumps GIAC_jll to v2.0.2 with
+# `GIAC_TYPE_ON_8BITS=1`, making `type` a plain byte at offset 0 and the ABI
+# compiler-invariant, followed by a `libgiac_julia_jll` bump. When both land,
+# these markers should start failing as unexpected passes — which is the point
+# of `@test_broken` over a skip. Same root cause as Giac.jl#22 and the probe
+# in Giac.jl#26.
+#
+# One thing this episode did establish about the bridge itself: its decode
+# *verifies itself* by re-encoding the candidate and comparing printed forms,
+# and that check is blind here. Re-encoding the truncated value also prints
+# twelve digits, the forms agree, and a wrong answer is confirmed. The check
+# establishes the printer's self-consistency, not its fidelity to the stored
+# value — the two coincide only where the tag is right.
 #
 # Everything else in the bridge passes on Windows: integers, rationals,
 # complex numbers, polynomials, vectors, matrices, refusals, variable names,


### PR DESCRIPTION
`main` is red on both Windows runners: **23 failures, all in `test_libpari_ext.jl`, all in reals.** Every other part of the bridge passes there. This stops the failure and documents the platform difference behind it.

## The cause

Not MPFR, which is what I guessed first. It is Giac's `Digits`.

On **Linux and macOS**, GIAC renders a `REAL` at *that value's* precision — 156 significant digits for a 512-bit value, exactly `ceil(p·log10 2)+1` — and the global `Digits` has no effect on it. The bridge reads a Giac `REAL` back by decoding its printed decimal, and relies on exactly that.

On **Windows**, GIAC honours `Digits` instead, whose default is 12:

```
expected  3.1415926535897932384626433832795028842
obtained  3.14159265359 0000062
```

Twelve significant digits at every precision requested — 64, 128, 192, 256, 384, 512 and 1024 all give the same twelve. A ceiling, not a rounding difference. `Digits` governs GIAC's *parser* on Windows too, so `convert(GiacExpr, ::BigFloat)` cannot even store a wide value: it lands on `DOUBLE` rather than `REAL`.

## The part worth reading

The decode **verifies itself**: it searches for the bit width whose re-encoding reproduces Giac's printed form character for character, and raises if none does. I described that in the docs as the thing that makes a text-mediated step safe.

**On Windows that check is blind.** Re-encoding the truncated value also prints twelve digits, the two forms agree, and a wrong answer is confirmed without complaint. The check establishes the printer's *self-consistency*, not its *fidelity to the stored value*. Those coincide only where the printer is faithful — which is precisely the property that fails here.

A guard that inspires confidence without providing it is worse than no guard. That is the useful lesson, and it is now written into both the test file and the docs.

## What this PR does

- Marks the 23 assertions `@test_broken` on Windows via a `@test_real` macro — **not** skipped. `@test_broken` reports an *error* if the expression starts passing, so whoever fixes the platform difference is told to remove the marker.
- Adds a **Reals do not cross on Windows** section to `docs/src/extensions/libpari.md`, an entry in the limitations list, and a `!!! warning` admonition on the reals section.
- **Corrects a false statement in the docs.** They claimed Giac's printer emits a `REAL` at the value's own precision "rather than at a global setting", presented as measured fact. It was measured on Linux only.

## Scope

Reals only. Integers, rationals, complex numbers, polynomials, vectors, matrices, the refusal list, variable names, the PARI stack check and the piracy check all pass on Windows. A `DOUBLE`, needing no more than twelve digits, crosses correctly.

**Deliberately not attempted here:** raising `Digits` around the read, which may well restore Windows entirely. It needs a Windows runner to judge, and I have none locally — it belongs on its own branch where CI can decide. This PR only stops `main` misreporting the state of the tests.

## Verification

Full suite on Linux: 9507 pass, 2 pre-existing broken, Aqua 10/10 — unchanged, since the macro resolves to a plain `@test` off Windows. Docs build with the same three pre-existing warnings. **The Windows behaviour of this change is verified by this PR's own CI, not by me.**

## How this got merged in the first place

The bridge was verified on Linux only, and the `CI (LibPARI bridge)` job I added alongside it runs ubuntu-only — so it gave a false sense of coverage while the real signal came from the main matrix, after merge. Worth considering whether that job should span the matrix, or whether its value is exactly its narrowness. I lean toward leaving it ubuntu-only and trusting the main matrix, but it is a fair question.