### PR TITLE
ci: run the macOS jobs natively on aarch64

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,28 @@ jobs:
           - windows-latest
         arch:
           - x64
+        # macos-latest is Apple Silicon. Asking for x64 there was tolerated by
+        # setup-julia v2 but is rejected outright by v3:
+        #
+        #   [setup-julia] x64 arch has been requested on a macOS runner that
+        #   has an arm64 (Apple Silicon) architecture
+        #
+        # so the macOS jobs run natively on aarch64. GIAC_jll,
+        # libgiac_julia_jll, libcxxwrap_julia_jll and PARI_jll all ship an
+        # aarch64-apple-darwin build, so nothing is lost by moving.
+        #
+        # Expressed as exclude/include rather than by dropping the `arch`
+        # dimension, so only the two macOS check names change.
+        exclude:
+          - os: macos-latest
+            arch: x64
+        include:
+          - os: macos-latest
+            arch: aarch64
+            version: '1.10'
+          - os: macos-latest
+            arch: aarch64
+            version: '1'
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The macOS CI jobs run natively on `aarch64`** instead of asking for `x64`.
+  `macos-latest` is Apple Silicon; `setup-julia` v2 tolerated the mismatch,
+  but v3 rejects it outright (*"x64 arch has been requested on a macOS runner
+  that has an arm64 (Apple Silicon) architecture"*), which is why
+  [#52](https://github.com/s-celles/Giac.jl/pull/52) fails on macOS. All four
+  binary dependencies — `GIAC_jll`, `libgiac_julia_jll`,
+  `libcxxwrap_julia_jll` and `PARI_jll` — ship an `aarch64-apple-darwin`
+  build, so nothing is lost by moving. Expressed as `exclude`/`include` rather
+  than by dropping the `arch` matrix dimension, so only the two macOS check
+  names change.
+
 ### Fixed
 
 - **The LibPARI bridge's real-number tests no longer fail the suite on


### PR DESCRIPTION
Unblocks [#52](https://github.com/s-celles/Giac.jl/pull/52) without touching the action version.

## Why

`macos-latest` is Apple Silicon. Asking for `arch: x64` there was tolerated by `setup-julia@v2` but is **rejected outright by v3**:

```
[setup-julia] x64 arch has been requested on a macOS runner that has an
arm64 (Apple Silicon) architecture
```

That is why #52 fails on both macOS runners after ten seconds — nothing to do with Julia or this package. It is the third time in this series that an action major needed a *configuration* change a bot cannot make, only the version bump it can.

This PR makes the config right. #52 stays free to be judged on its own merits afterwards.

## Checked before moving

All four binary dependencies ship an `aarch64-apple-darwin` build, so this is not one failure traded for another:

| | `aarch64-apple-darwin` |
|---|---|
| `GIAC_jll` | ✅ |
| `libgiac_julia_jll` | ✅ |
| `libcxxwrap_julia_jll` | ✅ |
| `PARI_jll` | ✅ |

## Check names change — two of them

Expressed as `exclude`/`include` rather than by dropping the `arch` matrix dimension. Dropping it would rename all six checks; this way only macOS moves:

```
Julia 1.10 - macos-latest - x64  ->  Julia 1.10 - macos-latest - aarch64
Julia 1    - macos-latest - x64  ->  Julia 1    - macos-latest - aarch64
```

Verified the matrix still expands to exactly six jobs, same versions and OSes as before.

⚠️ **If branch protection lists required checks by name, those two entries need updating** — otherwise the rule waits forever on checks that no longer exist. I cannot see your protection settings.

The ubuntu-only workflows keep their explicit `arch: x64`, which is correct for those runners.

## Testing

CI-configuration only — no package code, so the suite is unaffected and was not re-run. **The macOS behaviour of this change is verified by this PR's own CI, not by me**; I have no Apple Silicon machine.

Note that this PR's Windows checks will be red until [#56](https://github.com/s-celles/Giac.jl/pull/56) merges — that is `main`'s current bridge-reals failure, unrelated to anything here.