### PR TITLE
fix(ci): deploy the documentation from one workflow, not two

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -69,22 +69,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
-  docs:
-    name: Documentation
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      statuses: write
-    steps:
-      - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: julia-actions/cache@v3
-      - name: Install dependencies
-        run: julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-      - name: Build and deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia --project=docs docs/make.jl

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,6 +16,11 @@ concurrency:
 
 jobs:
   build:
+    # Named `Documentation` because the `Protect main` ruleset requires a
+    # status check by that exact name. It used to come from CI.yml's `docs`
+    # job, which deployed to gh-pages in parallel with this one; that job is
+    # gone, so this workflow now supplies the check.
+    name: Documentation
     permissions:
       contents: write
       statuses: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The documentation is no longer deployed twice on every push to `main`.**
+  Both `documentation.yml` and `CI.yml`'s `docs` job built the docs *and*
+  pushed to `gh-pages`, so the two raced; the merge of
+  [#58](https://github.com/s-celles/Giac.jl/pull/58) is where one lost, with
+  `error: failed to push some refs`. Earlier pushes passed on luck, not
+  correctness — the published docs were never wrong, only the CI colour was.
+  The `docs` job is removed and the dedicated workflow kept, since it also
+  covers tags (`tags: '*'`), which Documenter needs for versioned
+  deployments. Its job is renamed to `Documentation` because the `Protect
+  main` ruleset requires a status check under that exact name: without the
+  rename, every pull request would wait forever on a check no workflow
+  produced.
+
 - **The LibPARI bridge's real-number tests no longer fail the suite on
   Windows**, and the platform difference behind them is documented rather than
   hidden. `main` was red on both Windows runners with 23 failures, all of them


### PR DESCRIPTION
## The failure

Merging #58 turned CI red on `main` — not from a code or docs regression, but from a collision:

```
git push -q upstream HEAD:gh-pages
error: failed to push some refs to 'https://github.com/s-celles/Giac.jl.git'
```

`documentation.yml` and `CI.yml`'s `docs` job both run `docs/make.jl` with `DOCUMENTER_KEY`, so **both deploy to `gh-pages`**. They started in the same second (10:55:54); one pushed, the other hit a non-fast-forward.

Earlier pushes passed on luck — the race window is narrow, not absent. The published documentation was never wrong: the winning run deployed it correctly.

## The fix

Drop `CI.yml`'s `docs` job, keep the dedicated workflow — it also fires on `tags: '*'`, which Documenter needs for versioned deployments, while `CI.yml` only covers `v*`.

## The part that is not cosmetic

The `Protect main` ruleset lists **`Documentation`** among its required status checks, and that check was produced by the job being deleted — `documentation.yml` published its own under the name `build` (both are visible on #58). So its job is renamed to `Documentation`.

Without that rename, every future pull request would sit blocked forever, waiting on a required check no workflow produces. This PR is itself the test: its `Documentation` check must come from `documentation.yml`.