### PR TITLE
docs: add link to GiacSlate.jl in related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Giac.jl
 
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/s-celles/Giac.jl)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/JuliaGiac/Giac.jl)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18685533.svg)](https://doi.org/10.5281/zenodo.18685533)
-[![Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://s-celles.github.io/Giac.jl/stable)
-[![Documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://s-celles.github.io/Giac.jl/dev)
-[![CI](https://github.com/s-celles/Giac.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/s-celles/Giac.jl/actions/workflows/CI.yml)
-[![codecov](https://codecov.io/github/s-celles/Giac.jl/graph/badge.svg)](https://codecov.io/github/s-celles/Giac.jl)
+[![Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaGiac.github.io/Giac.jl/stable)
+[![Documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaGiac.github.io/Giac.jl/dev)
+[![CI](https://github.com/JuliaGiac/Giac.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/JuliaGiac/Giac.jl/actions/workflows/CI.yml)
+[![codecov](https://codecov.io/github/JuliaGiac/Giac.jl/graph/badge.svg)](https://codecov.io/github/JuliaGiac/Giac.jl)
 
 A Julia wrapper for the [Giac](https://www-fourier.univ-grenoble-alpes.fr/~parisse/giac.html) computer algebra system.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 A Julia wrapper for the [Giac](https://www-fourier.univ-grenoble-alpes.fr/~parisse/giac.html) computer algebra system.
 
 For LLM integration via the Model Context Protocol, see
-[`docs/src/extensions/mcp.md`](docs/src/extensions/mcp.md).
+[`docs/src/extensions/mcp.md`](https://juliagiac.github.io/Giac.jl/dev/extensions/mcp/).
+
+For a KaimonSlate integration, see [GiacSlate.jl](https://github.com/JuliaGiac/GiacSlate.jl).
 
 ## Contributors
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -187,3 +187,4 @@ integrate(exp(x), x, -Inf, 0)    # 1
 - [Giac](https://www-fourier.univ-grenoble-alpes.fr/~parisse/giac.html) - The underlying computer algebra system
 - [libgiac-julia-wrapper](https://github.com/s-celles/libgiac-julia-wrapper) - CxxWrap bindings for Giac
 - [CxxWrap.jl](https://github.com/JuliaInterop/CxxWrap.jl) - C++ wrapper generator for Julia
+- [GiacSlate.jl](https://github.com/JuliaGiac/GiacSlate.jl) - Integrates Giac.jl with KaimonSlate

--- a/docs/src/llms-full.txt
+++ b/docs/src/llms-full.txt
@@ -193,6 +193,7 @@ integrate(exp(x), x, -Inf, 0)    # 1
 - [Giac](https://www-fourier.univ-grenoble-alpes.fr/~parisse/giac.html) - The underlying computer algebra system
 - [libgiac-julia-wrapper](https://github.com/s-celles/libgiac-julia-wrapper) - CxxWrap bindings for Giac
 - [CxxWrap.jl](https://github.com/JuliaInterop/CxxWrap.jl) - C++ wrapper generator for Julia
+- [GiacSlate.jl](https://github.com/JuliaGiac/GiacSlate.jl) - Integrates Giac.jl with KaimonSlate
 
 
 ---


### PR DESCRIPTION
## Summary
- Add GiacSlate.jl to the Related Projects section (docs/src/index.md, regenerated llms-full.txt)
- Add a GiacSlate.jl mention in README.md